### PR TITLE
perf: improve bulk ghost rendering performance

### DIFF
--- a/Ghosting/Playback/BulkGhostBatching.cs
+++ b/Ghosting/Playback/BulkGhostBatching.cs
@@ -1,0 +1,14 @@
+namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
+
+public static class BulkGhostBatching
+{
+    public const int MaximumInstancesPerBatch = 1023;
+
+    public static int GetBatchCount(int instanceCount)
+    {
+        if (instanceCount <= 0)
+            return 0;
+
+        return (instanceCount + MaximumInstancesPerBatch - 1) / MaximumInstancesPerBatch;
+    }
+}

--- a/Ghosting/Playback/BulkGhostBatching.cs
+++ b/Ghosting/Playback/BulkGhostBatching.cs
@@ -11,4 +11,12 @@ public static class BulkGhostBatching
 
         return (instanceCount + MaximumInstancesPerBatch - 1) / MaximumInstancesPerBatch;
     }
+
+    public static int GetDrawCallCount(int instanceCount, int materialCount)
+    {
+        if (materialCount <= 0)
+            return 0;
+
+        return GetBatchCount(instanceCount) * materialCount;
+    }
 }

--- a/Ghosting/Playback/BulkGhostMeshScale.cs
+++ b/Ghosting/Playback/BulkGhostMeshScale.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
+
+public static class BulkGhostMeshScale
+{
+    public static float CalculateUniformScale(
+        float sourceMaximumSize,
+        float bakedMaximumSize,
+        float tolerance = 0.05f)
+    {
+        if (sourceMaximumSize <= 0 || bakedMaximumSize <= 0)
+            return 1;
+
+        float scale = sourceMaximumSize / bakedMaximumSize;
+        return Math.Abs(scale - 1) <= tolerance ? 1 : scale;
+    }
+}

--- a/Ghosting/Playback/BulkGhostModeState.cs
+++ b/Ghosting/Playback/BulkGhostModeState.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
+
+public sealed class BulkGhostModeState
+{
+    public bool IsActive { get; private set; }
+    public event Action Changed;
+
+    public void SetActive(bool active)
+    {
+        if (IsActive == active)
+            return;
+
+        IsActive = active;
+        Changed?.Invoke();
+    }
+}

--- a/Ghosting/Playback/BulkGhostRenderService.cs
+++ b/Ghosting/Playback/BulkGhostRenderService.cs
@@ -19,6 +19,7 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
     private readonly ConfigService _configService;
     private readonly PlayerLoopService _playerLoopService;
     private readonly PlayerLoopSubscription _lateUpdateSubscription;
+    private readonly BulkGhostModeState _bulkModeState;
     private readonly HashSet<Transform> _instances = new();
     private readonly Matrix4x4[] _matrices = new Matrix4x4[BulkGhostBatching.MaximumInstancesPerBatch];
 
@@ -31,11 +32,13 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
     public BulkGhostRenderService(
         ILogger<BulkGhostRenderService> logger,
         ConfigService configService,
-        PlayerLoopService playerLoopService)
+        PlayerLoopService playerLoopService,
+        BulkGhostModeState bulkModeState)
     {
         _logger = logger;
         _configService = configService;
         _playerLoopService = playerLoopService;
+        _bulkModeState = bulkModeState;
         _lateUpdateSubscription = playerLoopService.SubscribeLateUpdate(Draw);
     }
 
@@ -86,7 +89,7 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
             return;
         }
 
-        Material material = _configService.ShowGhostTransparent.Value
+        Material material = _configService.ShowGhostTransparent.Value && !_bulkModeState.IsActive
             ? _transparentMaterial
             : _opaqueMaterial;
 
@@ -158,12 +161,28 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
                     continue;
 
                 var bakedMesh = new Mesh();
-                renderer.BakeMesh(bakedMesh);
+                renderer.BakeMesh(bakedMesh, true);
                 bakedMeshes.Add(bakedMesh);
+
+                Matrix4x4 transform = rootInverse * Matrix4x4.TRS(
+                    renderer.transform.position,
+                    renderer.transform.rotation,
+                    Vector3.one);
+                Bounds bakedWorldBounds = TransformBounds(
+                    bakedMesh.bounds,
+                    Matrix4x4.TRS(
+                        renderer.transform.position,
+                        renderer.transform.rotation,
+                        Vector3.one));
+                float correction = BulkGhostMeshScale.CalculateUniformScale(
+                    MaximumComponent(renderer.bounds.size),
+                    MaximumComponent(bakedWorldBounds.size));
+                transform *= Matrix4x4.Scale(Vector3.one * correction);
+
                 AddSubMeshes(
                     combineInstances,
                     bakedMesh,
-                    rootInverse * renderer.transform.localToWorldMatrix);
+                    transform);
             }
 
             if (combineInstances.Count == 0)
@@ -220,6 +239,23 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
 
         return material;
     }
+
+    private static Bounds TransformBounds(Bounds bounds, Matrix4x4 matrix)
+    {
+        Vector3 center = matrix.MultiplyPoint3x4(bounds.center);
+        Vector3 extents = bounds.extents;
+        Vector3 axisX = matrix.MultiplyVector(new Vector3(extents.x, 0, 0));
+        Vector3 axisY = matrix.MultiplyVector(new Vector3(0, extents.y, 0));
+        Vector3 axisZ = matrix.MultiplyVector(new Vector3(0, 0, extents.z));
+        extents = new Vector3(
+            Math.Abs(axisX.x) + Math.Abs(axisY.x) + Math.Abs(axisZ.x),
+            Math.Abs(axisX.y) + Math.Abs(axisY.y) + Math.Abs(axisZ.y),
+            Math.Abs(axisX.z) + Math.Abs(axisY.z) + Math.Abs(axisZ.z));
+        return new Bounds(center, extents * 2);
+    }
+
+    private static float MaximumComponent(Vector3 vector) =>
+        Math.Max(vector.x, Math.Max(vector.y, vector.z));
 
     private void DisposeResources()
     {

--- a/Ghosting/Playback/BulkGhostRenderService.cs
+++ b/Ghosting/Playback/BulkGhostRenderService.cs
@@ -13,32 +13,25 @@ namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
 
 public sealed class BulkGhostRenderService : IEagerService, IDisposable
 {
-    private static readonly int ColorId = Shader.PropertyToID("_Color");
-
     private readonly ILogger<BulkGhostRenderService> _logger;
     private readonly ConfigService _configService;
     private readonly PlayerLoopService _playerLoopService;
     private readonly PlayerLoopSubscription _lateUpdateSubscription;
-    private readonly BulkGhostModeState _bulkModeState;
     private readonly HashSet<Transform> _instances = new();
     private readonly Matrix4x4[] _matrices = new Matrix4x4[BulkGhostBatching.MaximumInstancesPerBatch];
 
-    private Mesh _mesh;
-    private Material _opaqueMaterial;
-    private Material _transparentMaterial;
+    private readonly List<RenderPart> _renderParts = new();
     private bool _initializationAttempted;
     private bool _initialized;
 
     public BulkGhostRenderService(
         ILogger<BulkGhostRenderService> logger,
         ConfigService configService,
-        PlayerLoopService playerLoopService,
-        BulkGhostModeState bulkModeState)
+        PlayerLoopService playerLoopService)
     {
         _logger = logger;
         _configService = configService;
         _playerLoopService = playerLoopService;
-        _bulkModeState = bulkModeState;
         _lateUpdateSubscription = playerLoopService.SubscribeLateUpdate(Draw);
     }
 
@@ -89,10 +82,6 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
             return;
         }
 
-        Material material = _configService.ShowGhostTransparent.Value && !_bulkModeState.IsActive
-            ? _transparentMaterial
-            : _opaqueMaterial;
-
         int count = 0;
         foreach (Transform instance in _instances)
         {
@@ -103,29 +92,32 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
             if (count != BulkGhostBatching.MaximumInstancesPerBatch)
                 continue;
 
-            DrawBatch(material, count);
+            DrawBatch(count);
             count = 0;
         }
 
         if (count > 0)
-            DrawBatch(material, count);
+            DrawBatch(count);
     }
 
-    private void DrawBatch(Material material, int count)
+    private void DrawBatch(int count)
     {
-        Graphics.DrawMeshInstanced(
-            _mesh,
-            0,
-            material,
-            _matrices,
-            count,
-            null,
-            ShadowCastingMode.Off,
-            false,
-            0,
-            null,
-            LightProbeUsage.Off,
-            null);
+        foreach (RenderPart part in _renderParts)
+        {
+            Graphics.DrawMeshInstanced(
+                part.Mesh,
+                0,
+                part.Material,
+                _matrices,
+                count,
+                null,
+                ShadowCastingMode.Off,
+                false,
+                0,
+                null,
+                LightProbeUsage.Off,
+                null);
+        }
     }
 
     private void InitializeResources()
@@ -141,7 +133,7 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
             GhostVisuals.ConfigureBulkModel(model);
 
             Matrix4x4 rootInverse = templateRoot.transform.worldToLocalMatrix;
-            var combineInstances = new List<CombineInstance>();
+            var materialGroups = new Dictionary<Material, List<CombineInstance>>();
 
             foreach (MeshFilter filter in model.GetComponentsInChildren<MeshFilter>(false))
             {
@@ -149,10 +141,11 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
                 if (renderer == null || !renderer.enabled || filter.sharedMesh == null)
                     continue;
 
-                AddSubMeshes(
-                    combineInstances,
+                AddSubMeshesByMaterial(
+                    materialGroups,
                     filter.sharedMesh,
-                    rootInverse * filter.transform.localToWorldMatrix);
+                    rootInverse * filter.transform.localToWorldMatrix,
+                    renderer.sharedMaterials);
             }
 
             foreach (SkinnedMeshRenderer renderer in model.GetComponentsInChildren<SkinnedMeshRenderer>(false))
@@ -179,27 +172,34 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
                     MaximumComponent(bakedWorldBounds.size));
                 transform *= Matrix4x4.Scale(Vector3.one * correction);
 
-                AddSubMeshes(
-                    combineInstances,
+                AddSubMeshesByMaterial(
+                    materialGroups,
                     bakedMesh,
-                    transform);
+                    transform,
+                    renderer.sharedMaterials);
             }
 
-            if (combineInstances.Count == 0)
+            if (materialGroups.Count == 0)
                 throw new InvalidOperationException("Bulk ghost template contains no active meshes.");
 
-            _mesh = new Mesh
+            int partIndex = 0;
+            foreach (KeyValuePair<Material, List<CombineInstance>> materialGroup in materialGroups)
             {
-                name = "GTR Instanced Bulk Ghost",
-                indexFormat = IndexFormat.UInt32
-            };
-            _mesh.CombineMeshes(combineInstances.ToArray(), true, true, false);
-            _mesh.RecalculateBounds();
+                var mesh = new Mesh
+                {
+                    name = $"GTR Instanced Bulk Ghost {partIndex++}",
+                    indexFormat = IndexFormat.UInt32
+                };
+                mesh.CombineMeshes(materialGroup.Value.ToArray(), true, true, false);
+                mesh.RecalculateBounds();
 
-            Material source =
-                ComponentCache.Get<NetworkedGhostSpawner>().zeepkistGhostPrefab.ghostFader.fadeThisMaterial;
-            _opaqueMaterial = CreateMaterial(source, 1f);
-            _transparentMaterial = CreateMaterial(source, 0.3f);
+                var material = new Material(materialGroup.Key)
+                {
+                    enableInstancing = true,
+                    name = $"GTR Instanced {materialGroup.Key.name}"
+                };
+                _renderParts.Add(new RenderPart(mesh, material));
+            }
         }
         finally
         {
@@ -211,33 +211,34 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
         }
     }
 
-    private static void AddSubMeshes(
-        ICollection<CombineInstance> destination,
+    private static void AddSubMeshesByMaterial(
+        IDictionary<Material, List<CombineInstance>> destination,
         Mesh mesh,
-        Matrix4x4 transform)
+        Matrix4x4 transform,
+        IReadOnlyList<Material> materials)
     {
         for (int subMesh = 0; subMesh < mesh.subMeshCount; subMesh++)
         {
-            destination.Add(new CombineInstance
+            if (materials.Count == 0)
+                continue;
+
+            Material material = materials[Math.Min(subMesh, materials.Count - 1)];
+            if (material == null)
+                continue;
+
+            if (!destination.TryGetValue(material, out List<CombineInstance> instances))
+            {
+                instances = new List<CombineInstance>();
+                destination.Add(material, instances);
+            }
+
+            instances.Add(new CombineInstance
             {
                 mesh = mesh,
                 subMeshIndex = subMesh,
                 transform = transform
             });
         }
-    }
-
-    private static Material CreateMaterial(Material source, float alpha)
-    {
-        var material = new Material(source)
-        {
-            enableInstancing = true
-        };
-
-        if (material.HasProperty(ColorId))
-            material.color = Color.white with { a = alpha };
-
-        return material;
     }
 
     private static Bounds TransformBounds(Bounds bounds, Matrix4x4 matrix)
@@ -259,16 +260,13 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
 
     private void DisposeResources()
     {
-        if (_mesh != null)
-            Object.Destroy(_mesh);
-        if (_opaqueMaterial != null)
-            Object.Destroy(_opaqueMaterial);
-        if (_transparentMaterial != null)
-            Object.Destroy(_transparentMaterial);
+        foreach (RenderPart part in _renderParts)
+        {
+            Object.Destroy(part.Mesh);
+            Object.Destroy(part.Material);
+        }
 
-        _mesh = null;
-        _opaqueMaterial = null;
-        _transparentMaterial = null;
+        _renderParts.Clear();
         _initialized = false;
     }
 
@@ -277,5 +275,17 @@ public sealed class BulkGhostRenderService : IEagerService, IDisposable
         _playerLoopService.UnsubscribeLateUpdate(_lateUpdateSubscription);
         _instances.Clear();
         DisposeResources();
+    }
+
+    private sealed class RenderPart
+    {
+        public RenderPart(Mesh mesh, Material material)
+        {
+            Mesh = mesh;
+            Material = material;
+        }
+
+        public Mesh Mesh { get; }
+        public Material Material { get; }
     }
 }

--- a/Ghosting/Playback/BulkGhostRenderService.cs
+++ b/Ghosting/Playback/BulkGhostRenderService.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using TNRD.Zeepkist.GTR.Configuration;
+using TNRD.Zeepkist.GTR.Core;
+using TNRD.Zeepkist.GTR.PlayerLoop;
+using UnityEngine;
+using UnityEngine.Rendering;
+using ZeepSDK.Utilities;
+using Object = UnityEngine.Object;
+
+namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
+
+public sealed class BulkGhostRenderService : IEagerService, IDisposable
+{
+    private static readonly int ColorId = Shader.PropertyToID("_Color");
+
+    private readonly ILogger<BulkGhostRenderService> _logger;
+    private readonly ConfigService _configService;
+    private readonly PlayerLoopService _playerLoopService;
+    private readonly PlayerLoopSubscription _lateUpdateSubscription;
+    private readonly HashSet<Transform> _instances = new();
+    private readonly Matrix4x4[] _matrices = new Matrix4x4[BulkGhostBatching.MaximumInstancesPerBatch];
+
+    private Mesh _mesh;
+    private Material _opaqueMaterial;
+    private Material _transparentMaterial;
+    private bool _initializationAttempted;
+    private bool _initialized;
+
+    public BulkGhostRenderService(
+        ILogger<BulkGhostRenderService> logger,
+        ConfigService configService,
+        PlayerLoopService playerLoopService)
+    {
+        _logger = logger;
+        _configService = configService;
+        _playerLoopService = playerLoopService;
+        _lateUpdateSubscription = playerLoopService.SubscribeLateUpdate(Draw);
+    }
+
+    public bool CanUseInstancing()
+    {
+        if (_initializationAttempted)
+            return _initialized;
+
+        _initializationAttempted = true;
+        if (!SystemInfo.supportsInstancing)
+        {
+            _logger.LogWarning("GPU instancing is unavailable. Falling back to bulk ghost renderers.");
+            return false;
+        }
+
+        try
+        {
+            InitializeResources();
+            _initialized = true;
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Unable to initialize instanced bulk ghost rendering. Falling back.");
+            DisposeResources();
+        }
+
+        return _initialized;
+    }
+
+    public void Register(Transform transform)
+    {
+        if (transform != null)
+            _instances.Add(transform);
+    }
+
+    public void Unregister(Transform transform)
+    {
+        if (transform != null)
+            _instances.Remove(transform);
+    }
+
+    private void Draw()
+    {
+        if (!_initialized ||
+            !_configService.ShowGhosts.Value ||
+            !_configService.ShowGlobalPersonalBest.Value)
+        {
+            return;
+        }
+
+        Material material = _configService.ShowGhostTransparent.Value
+            ? _transparentMaterial
+            : _opaqueMaterial;
+
+        int count = 0;
+        foreach (Transform instance in _instances)
+        {
+            if (instance == null || !instance.gameObject.activeInHierarchy)
+                continue;
+
+            _matrices[count++] = instance.localToWorldMatrix;
+            if (count != BulkGhostBatching.MaximumInstancesPerBatch)
+                continue;
+
+            DrawBatch(material, count);
+            count = 0;
+        }
+
+        if (count > 0)
+            DrawBatch(material, count);
+    }
+
+    private void DrawBatch(Material material, int count)
+    {
+        Graphics.DrawMeshInstanced(
+            _mesh,
+            0,
+            material,
+            _matrices,
+            count,
+            null,
+            ShadowCastingMode.Off,
+            false,
+            0,
+            null,
+            LightProbeUsage.Off,
+            null);
+    }
+
+    private void InitializeResources()
+    {
+        GameObject templateRoot = new("GTR Bulk Ghost Mesh Template");
+        var bakedMeshes = new List<Mesh>();
+
+        try
+        {
+            SetupModelCar model = Object.Instantiate(
+                ComponentCache.Get<NetworkedGhostSpawner>().zeepkistGhostPrefab.ghostModel,
+                templateRoot.transform);
+            GhostVisuals.ConfigureBulkModel(model);
+
+            Matrix4x4 rootInverse = templateRoot.transform.worldToLocalMatrix;
+            var combineInstances = new List<CombineInstance>();
+
+            foreach (MeshFilter filter in model.GetComponentsInChildren<MeshFilter>(false))
+            {
+                MeshRenderer renderer = filter.GetComponent<MeshRenderer>();
+                if (renderer == null || !renderer.enabled || filter.sharedMesh == null)
+                    continue;
+
+                AddSubMeshes(
+                    combineInstances,
+                    filter.sharedMesh,
+                    rootInverse * filter.transform.localToWorldMatrix);
+            }
+
+            foreach (SkinnedMeshRenderer renderer in model.GetComponentsInChildren<SkinnedMeshRenderer>(false))
+            {
+                if (!renderer.enabled || renderer.sharedMesh == null)
+                    continue;
+
+                var bakedMesh = new Mesh();
+                renderer.BakeMesh(bakedMesh);
+                bakedMeshes.Add(bakedMesh);
+                AddSubMeshes(
+                    combineInstances,
+                    bakedMesh,
+                    rootInverse * renderer.transform.localToWorldMatrix);
+            }
+
+            if (combineInstances.Count == 0)
+                throw new InvalidOperationException("Bulk ghost template contains no active meshes.");
+
+            _mesh = new Mesh
+            {
+                name = "GTR Instanced Bulk Ghost",
+                indexFormat = IndexFormat.UInt32
+            };
+            _mesh.CombineMeshes(combineInstances.ToArray(), true, true, false);
+            _mesh.RecalculateBounds();
+
+            Material source =
+                ComponentCache.Get<NetworkedGhostSpawner>().zeepkistGhostPrefab.ghostFader.fadeThisMaterial;
+            _opaqueMaterial = CreateMaterial(source, 1f);
+            _transparentMaterial = CreateMaterial(source, 0.3f);
+        }
+        finally
+        {
+            foreach (Mesh bakedMesh in bakedMeshes)
+                Object.Destroy(bakedMesh);
+
+            templateRoot.SetActive(false);
+            Object.Destroy(templateRoot);
+        }
+    }
+
+    private static void AddSubMeshes(
+        ICollection<CombineInstance> destination,
+        Mesh mesh,
+        Matrix4x4 transform)
+    {
+        for (int subMesh = 0; subMesh < mesh.subMeshCount; subMesh++)
+        {
+            destination.Add(new CombineInstance
+            {
+                mesh = mesh,
+                subMeshIndex = subMesh,
+                transform = transform
+            });
+        }
+    }
+
+    private static Material CreateMaterial(Material source, float alpha)
+    {
+        var material = new Material(source)
+        {
+            enableInstancing = true
+        };
+
+        if (material.HasProperty(ColorId))
+            material.color = Color.white with { a = alpha };
+
+        return material;
+    }
+
+    private void DisposeResources()
+    {
+        if (_mesh != null)
+            Object.Destroy(_mesh);
+        if (_opaqueMaterial != null)
+            Object.Destroy(_opaqueMaterial);
+        if (_transparentMaterial != null)
+            Object.Destroy(_transparentMaterial);
+
+        _mesh = null;
+        _opaqueMaterial = null;
+        _transparentMaterial = null;
+        _initialized = false;
+    }
+
+    public void Dispose()
+    {
+        _playerLoopService.UnsubscribeLateUpdate(_lateUpdateSubscription);
+        _instances.Clear();
+        DisposeResources();
+    }
+}

--- a/Ghosting/Playback/GhostData.cs
+++ b/Ghosting/Playback/GhostData.cs
@@ -5,10 +5,16 @@ namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
 
 public class GhostData
 {
-    public GhostData(GhostVisuals ghostVisuals, GhostVisualProfile visualProfile)
+    public GhostData(
+        GameObject gameObject,
+        GhostVisuals ghostVisuals,
+        GhostVisualProfile visualProfile,
+        bool isInstanced)
     {
+        GameObject = gameObject;
         Visuals = ghostVisuals;
         VisualProfile = visualProfile;
+        IsInstanced = isInstanced;
         Object.DontDestroyOnLoad(GameObject.transform.root.gameObject);
     }
 
@@ -32,7 +38,8 @@ public class GhostData
     public IGhost Ghost { get; private set; }
     public GhostType Type { get; private set; }
     public GhostVisualProfile VisualProfile { get; }
-    public GameObject GameObject => Visuals.GhostModel.gameObject;
+    public bool IsInstanced { get; }
+    public GameObject GameObject { get; }
     public GhostVisuals Visuals { get; private set; }
     public GhostRenderer Renderer { get; private set; }
     public RoyTheunissen.FMODSyntax.FmodAudioPlayback CurrentHorn { get; set; }
@@ -44,5 +51,13 @@ public class GhostData
     {
         Renderer?.Dispose();
         Renderer = null;
+    }
+
+    public void SetActive(bool active)
+    {
+        if (Visuals != null)
+            Visuals.gameObject.SetActive(active);
+
+        GameObject.SetActive(active);
     }
 }

--- a/Ghosting/Playback/GhostLoadBudget.cs
+++ b/Ghosting/Playback/GhostLoadBudget.cs
@@ -1,0 +1,18 @@
+namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
+
+public static class GhostLoadBudget
+{
+    public const int MaximumAdditionsPerFrame = 16;
+    public const double MaximumMillisecondsPerFrame = 2;
+
+    public static bool CanProcessNext(int processedCount, double elapsedMilliseconds)
+    {
+        return processedCount < MaximumAdditionsPerFrame &&
+               elapsedMilliseconds < MaximumMillisecondsPerFrame;
+    }
+
+    public static bool IsCurrentGeneration(int operationGeneration, int currentGeneration)
+    {
+        return operationGeneration == currentGeneration;
+    }
+}

--- a/Ghosting/Playback/GhostLoadProgress.cs
+++ b/Ghosting/Playback/GhostLoadProgress.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
+
+public static class GhostLoadProgress
+{
+    public const int ReportStepPercent = 5;
+
+    public static int CalculatePercent(int completed, int total)
+    {
+        if (total <= 0)
+            return 100;
+
+        return Math.Min(100, Math.Max(0, completed * 100 / total));
+    }
+
+    public static bool ShouldReport(int percent, int lastReportedPercent)
+    {
+        return percent == 100 || percent >= lastReportedPercent + ReportStepPercent;
+    }
+}

--- a/Ghosting/Playback/GhostLoadProgress.cs
+++ b/Ghosting/Playback/GhostLoadProgress.cs
@@ -4,18 +4,11 @@ namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
 
 public static class GhostLoadProgress
 {
-    public const int ReportStepPercent = 5;
-
     public static int CalculatePercent(int completed, int total)
     {
         if (total <= 0)
             return 100;
 
         return Math.Min(100, Math.Max(0, completed * 100 / total));
-    }
-
-    public static bool ShouldReport(int percent, int lastReportedPercent)
-    {
-        return percent == 100 || percent >= lastReportedPercent + ReportStepPercent;
     }
 }

--- a/Ghosting/Playback/GhostLoadProgress.cs
+++ b/Ghosting/Playback/GhostLoadProgress.cs
@@ -11,4 +11,9 @@ public static class GhostLoadProgress
 
         return Math.Min(100, Math.Max(0, completed * 100 / total));
     }
+
+    public static bool HasAdvanced(int completed, int lastReportedCompleted)
+    {
+        return completed > lastReportedCompleted;
+    }
 }

--- a/Ghosting/Playback/GhostMaterialService.cs
+++ b/Ghosting/Playback/GhostMaterialService.cs
@@ -6,26 +6,31 @@ using UnityEngine;
 
 namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
 
-public class GhostMaterialService : IEagerService
+public class GhostMaterialService : IEagerService, System.IDisposable
 {
     private readonly PlayerLoopService _playerLoopService;
     private readonly GhostPlayer _ghostPlayer;
     private readonly ConfigService _configService;
     private readonly MessengerService _messengerService;
+    private readonly BulkGhostModeState _bulkModeState;
+    private readonly PlayerLoopSubscription _updateSubscription;
 
     public GhostMaterialService(
         PlayerLoopService playerLoopService,
         GhostPlayer ghostPlayer,
         ConfigService configService,
-        MessengerService messengerService)
+        MessengerService messengerService,
+        BulkGhostModeState bulkModeState)
     {
         _playerLoopService = playerLoopService;
         _ghostPlayer = ghostPlayer;
         _configService = configService;
         _messengerService = messengerService;
+        _bulkModeState = bulkModeState;
 
-        _playerLoopService.SubscribeUpdate(OnUpdate);
+        _updateSubscription = _playerLoopService.SubscribeUpdate(OnUpdate);
         _ghostPlayer.GhostAdded += OnGhostAdded;
+        _bulkModeState.Changed += ApplyMaterialMode;
     }
 
     private void OnGhostAdded(object sender, GhostPlayer.GhostAddedEventArgs e)
@@ -35,7 +40,7 @@ public class GhostMaterialService : IEagerService
         if (e.GhostData.IsInstanced)
             return;
 
-        if (_configService.ShowGhostTransparent.Value)
+        if (UseTransparency)
         {
             e.GhostData.Renderer.SwitchToGhost();
         }
@@ -58,20 +63,7 @@ public class GhostMaterialService : IEagerService
 
         _configService.ShowGhostTransparent.Value = !_configService.ShowGhostTransparent.Value;
 
-        foreach (GhostData ghostData in _ghostPlayer.ActiveGhosts)
-        {
-            if (ghostData.IsInstanced)
-                continue;
-
-            if (_configService.ShowGhostTransparent.Value)
-            {
-                ghostData.Renderer.SwitchToGhost();
-            }
-            else
-            {
-                ghostData.Renderer.SwitchToNormal();
-            }
-        }
+        ApplyMaterialMode();
 
         if (_configService.ShowGhostTransparent.Value)
         {
@@ -85,6 +77,9 @@ public class GhostMaterialService : IEagerService
 
     private void UpdateRenderers()
     {
+        if (_bulkModeState.IsActive)
+            return;
+
         foreach (GhostData ghostData in _ghostPlayer.ActiveGhosts)
         {
             UpdateRenderer(ghostData);
@@ -98,7 +93,7 @@ public class GhostMaterialService : IEagerService
 
         const float minDistance = 2.5f;
         const float maxDistance = 8f;
-        float maxAlpha = _configService.ShowGhostTransparent.Value ? 0.3f : 1f;
+        float maxAlpha = UseTransparency ? 0.3f : 1f;
 
         if (PlayerManager.Instance == null || PlayerManager.Instance.currentMaster == null)
             return;
@@ -124,7 +119,7 @@ public class GhostMaterialService : IEagerService
             a = inverseLerp
         };
 
-        if (_configService.ShowGhostTransparent.Value)
+        if (UseTransparency)
         {
             Color color = ghostData.Ghost.Color with
             {
@@ -137,5 +132,34 @@ public class GhostMaterialService : IEagerService
         {
             ghostData.Renderer.SetFade(fadeAmount);
         }
+    }
+
+    private bool UseTransparency =>
+        _configService.ShowGhostTransparent.Value && !_bulkModeState.IsActive;
+
+    private void ApplyMaterialMode()
+    {
+        foreach (GhostData ghostData in _ghostPlayer.ActiveGhosts)
+        {
+            if (ghostData.IsInstanced)
+                continue;
+
+            if (UseTransparency)
+            {
+                ghostData.Renderer.SwitchToGhost();
+            }
+            else
+            {
+                ghostData.Renderer.SwitchToNormal();
+                ghostData.Renderer.SetFade(1);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _playerLoopService.UnsubscribeUpdate(_updateSubscription);
+        _ghostPlayer.GhostAdded -= OnGhostAdded;
+        _bulkModeState.Changed -= ApplyMaterialMode;
     }
 }

--- a/Ghosting/Playback/GhostMaterialService.cs
+++ b/Ghosting/Playback/GhostMaterialService.cs
@@ -30,7 +30,10 @@ public class GhostMaterialService : IEagerService
 
     private void OnGhostAdded(object sender, GhostPlayer.GhostAddedEventArgs e)
     {
-        e.GhostData.GameObject.SetActive(_configService.ShowGhosts.Value);
+        e.GhostData.SetActive(_configService.ShowGhosts.Value);
+
+        if (e.GhostData.IsInstanced)
+            return;
 
         if (_configService.ShowGhostTransparent.Value)
         {
@@ -57,6 +60,9 @@ public class GhostMaterialService : IEagerService
 
         foreach (GhostData ghostData in _ghostPlayer.ActiveGhosts)
         {
+            if (ghostData.IsInstanced)
+                continue;
+
             if (_configService.ShowGhostTransparent.Value)
             {
                 ghostData.Renderer.SwitchToGhost();

--- a/Ghosting/Playback/GhostNamePositioniongService.cs
+++ b/Ghosting/Playback/GhostNamePositioniongService.cs
@@ -6,26 +6,31 @@ using UnityEngine;
 
 namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
 
-public class GhostNamePositioniongService : IEagerService
+public class GhostNamePositioniongService : IEagerService, System.IDisposable
 {
     private readonly PlayerLoopService _playerLoopService;
     private readonly GhostPlayer _ghostPlayer;
     private readonly ConfigService _configService;
     private readonly MessengerService _messengerService;
+    private readonly BulkGhostModeState _bulkModeState;
+    private readonly PlayerLoopSubscription _updateSubscription;
 
     public GhostNamePositioniongService(
         PlayerLoopService playerLoopService,
         GhostPlayer ghostPlayer,
         ConfigService configService,
-        MessengerService messengerService)
+        MessengerService messengerService,
+        BulkGhostModeState bulkModeState)
     {
         _playerLoopService = playerLoopService;
         _ghostPlayer = ghostPlayer;
         _configService = configService;
         _messengerService = messengerService;
+        _bulkModeState = bulkModeState;
 
-        _playerLoopService.SubscribeUpdate(OnUpdate);
+        _updateSubscription = _playerLoopService.SubscribeUpdate(OnUpdate);
         _ghostPlayer.GhostAdded += OnGhostAdded;
+        _bulkModeState.Changed += OnBulkModeChanged;
     }
 
     private void OnGhostAdded(object sender, GhostPlayer.GhostAddedEventArgs e)
@@ -40,6 +45,9 @@ public class GhostNamePositioniongService : IEagerService
 
         ghostData.Visuals.NameDisplay.gameObject.SetActive(
             _configService.ShowGhostNames.Value && _configService.ShowGhosts.Value);
+
+        if (_bulkModeState.IsActive)
+            SetNameAlpha(ghostData, 1);
     }
 
     private void OnUpdate()
@@ -106,5 +114,29 @@ public class GhostNamePositioniongService : IEagerService
         nameDisplayTransform.position = ghostData.GameObject.transform.position + Vector3.up * 2.5f;
         nameDisplayTransform.LookAt(cameraPosition);
         nameDisplayTransform.LookAt(nameDisplayTransform.position - nameDisplayTransform.forward);
+    }
+
+    private void OnBulkModeChanged()
+    {
+        foreach (GhostData ghostData in _ghostPlayer.ActiveGhosts)
+        {
+            UpdateVisibility(ghostData);
+        }
+    }
+
+    private static void SetNameAlpha(GhostData ghostData, float alpha)
+    {
+        ghostData.Visuals.NameDisplay.theDisplayName.color =
+            ghostData.Visuals.NameDisplay.theDisplayName.color with
+            {
+                a = alpha
+            };
+    }
+
+    public void Dispose()
+    {
+        _playerLoopService.UnsubscribeUpdate(_updateSubscription);
+        _ghostPlayer.GhostAdded -= OnGhostAdded;
+        _bulkModeState.Changed -= OnBulkModeChanged;
     }
 }

--- a/Ghosting/Playback/GhostPlayer.cs
+++ b/Ghosting/Playback/GhostPlayer.cs
@@ -15,11 +15,8 @@ namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
 
 public partial class GhostPlayer : IEagerService, IDisposable
 {
-    private readonly ObjectPool<GhostData> _fullPool =
-        new(CreateFullGhost, GetGhost, ReleaseGhost, DestroyGhost);
-
-    private readonly ObjectPool<GhostData> _bulkPool =
-        new(CreateBulkGhost, GetGhost, ReleaseGhost, DestroyGhost);
+    private readonly ObjectPool<GhostData> _fullPool;
+    private readonly ObjectPool<GhostData> _bulkPool;
 
     private static ILogger<GhostPlayer> _logger;
 
@@ -27,6 +24,7 @@ public partial class GhostPlayer : IEagerService, IDisposable
     private readonly Dictionary<int, GhostData> _ghostData = new();
     private readonly HashSet<int> _ghostsToRemove = new();
     private readonly PlayerLoopService _playerLoopService;
+    private readonly BulkGhostRenderService _bulkGhostRenderService;
     private readonly PlayerLoopSubscription _updateSubscription;
     private readonly PlayerLoopSubscription _fixedUpdateSubscription;
 
@@ -38,10 +36,24 @@ public partial class GhostPlayer : IEagerService, IDisposable
     public event EventHandler<GhostAddedEventArgs> GhostAdded;
     public event EventHandler<GhostRemovedEventArgs> GhostRemoved;
 
-    public GhostPlayer(PlayerLoopService playerLoopService, ILogger<GhostPlayer> logger)
+    public GhostPlayer(
+        PlayerLoopService playerLoopService,
+        BulkGhostRenderService bulkGhostRenderService,
+        ILogger<GhostPlayer> logger)
     {
         _logger = logger;
         _playerLoopService = playerLoopService;
+        _bulkGhostRenderService = bulkGhostRenderService;
+        _fullPool = new ObjectPool<GhostData>(
+            CreateFullGhost,
+            GetGhost,
+            ReleaseGhost,
+            DestroyGhost);
+        _bulkPool = new ObjectPool<GhostData>(
+            CreateBulkGhost,
+            GetGhost,
+            ReleaseGhost,
+            DestroyGhost);
 
         _updateSubscription = playerLoopService.SubscribeUpdate(Update);
         _fixedUpdateSubscription = playerLoopService.SubscribeFixedUpdate(FixedUpdate);
@@ -53,31 +65,40 @@ public partial class GhostPlayer : IEagerService, IDisposable
         MultiplayerApi.DisconnectedFromGame += OnDisconnectedFromGame;
     }
 
-    private static GhostData CreateFullGhost()
+    private GhostData CreateFullGhost()
     {
-        return CreateGhost(GhostVisualProfile.Full);
+        return CreateVisualGhost(GhostVisualProfile.Full);
     }
 
-    private static GhostData CreateBulkGhost()
+    private GhostData CreateBulkGhost()
     {
-        GhostData ghostData = CreateGhost(GhostVisualProfile.Bulk);
+        if (_bulkGhostRenderService.CanUseInstancing())
+        {
+            var gameObject = new GameObject("Instanced Bulk Ghost");
+            return new GhostData(gameObject, null, GhostVisualProfile.Bulk, true);
+        }
+
+        GhostData ghostData = CreateVisualGhost(GhostVisualProfile.Bulk);
         ghostData.InitializeRenderer();
         return ghostData;
     }
 
-    private static GhostData CreateGhost(GhostVisualProfile visualProfile)
+    private static GhostData CreateVisualGhost(GhostVisualProfile visualProfile)
     {
         GameObject gameObject = new("Ghost");
         Object.DontDestroyOnLoad(gameObject.transform.root.gameObject);
         GhostVisuals ghostVisuals = gameObject.AddComponent<GhostVisuals>();
         ghostVisuals.Initialize(visualProfile);
-        return new GhostData(ghostVisuals, visualProfile);
+        return new GhostData(
+            ghostVisuals.GhostModel.gameObject,
+            ghostVisuals,
+            visualProfile,
+            false);
     }
 
     private static void GetGhost(GhostData ghostData)
     {
-        ghostData.GameObject.SetActive(true);
-        ghostData.Visuals.gameObject.SetActive(true);
+        ghostData.SetActive(true);
     }
 
     private static void ReleaseGhost(GhostData ghostData)
@@ -85,15 +106,16 @@ public partial class GhostPlayer : IEagerService, IDisposable
         ghostData.CurrentHorn?.Stop();
         ghostData.CurrentHorn?.Cleanup();
         ghostData.CurrentHorn = null;
-        ghostData.Visuals.gameObject.SetActive(false);
-        ghostData.GameObject.SetActive(false);
+        ghostData.SetActive(false);
     }
 
     private static void DestroyGhost(GhostData ghostData)
     {
         ghostData.DisposeRenderer();
-        if (ghostData.Visuals.gameObject != null)
+        if (ghostData.Visuals != null && ghostData.Visuals.gameObject != null)
             Object.Destroy(ghostData.Visuals.gameObject);
+        else if (ghostData.GameObject != null)
+            Object.Destroy(ghostData.GameObject);
     }
 
     private void OnRoundStarted()
@@ -195,6 +217,9 @@ public partial class GhostPlayer : IEagerService, IDisposable
             ghostData.InitializeRenderer();
         }
 
+        if (ghostData.IsInstanced)
+            _bulkGhostRenderService.Register(ghostData.GameObject.transform);
+
         if (!hadExistingGhost)
         {
             _ghosts.Add(recordId, ghost);
@@ -217,6 +242,9 @@ public partial class GhostPlayer : IEagerService, IDisposable
 
         if (_ghostData.TryGetValue(recordId, out GhostData ghostData))
         {
+            if (ghostData.IsInstanced)
+                _bulkGhostRenderService.Unregister(ghostData.GameObject.transform);
+
             GetPool(ghostData.VisualProfile).Release(ghostData);
             GhostRemoved?.Invoke(this, new GhostRemovedEventArgs(recordId));
         }

--- a/Ghosting/Playback/GhostPlayer.cs
+++ b/Ghosting/Playback/GhostPlayer.cs
@@ -182,6 +182,12 @@ public partial class GhostPlayer : IEagerService, IDisposable
         return _ghosts.ContainsKey(recordId);
     }
 
+    public bool HasGhost(int recordId, GhostVisualProfile visualProfile)
+    {
+        return _ghostData.TryGetValue(recordId, out GhostData ghostData) &&
+               ghostData.VisualProfile == visualProfile;
+    }
+
     public void AddGhost(
         GhostType type,
         int recordId,

--- a/Ghosting/Playback/GhostReconciliation.cs
+++ b/Ghosting/Playback/GhostReconciliation.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
+
+public static class GhostReconciliation
+{
+    public static IReadOnlyList<int> GetObsoleteIds(
+        IEnumerable<int> loadedIds,
+        ISet<int> desiredIds)
+    {
+        var obsoleteIds = new List<int>();
+        foreach (int loadedId in loadedIds)
+        {
+            if (!desiredIds.Contains(loadedId))
+                obsoleteIds.Add(loadedId);
+        }
+
+        return obsoleteIds;
+    }
+}

--- a/Ghosting/Playback/GhostRepository.cs
+++ b/Ghosting/Playback/GhostRepository.cs
@@ -22,6 +22,7 @@ public class GhostRepository
     private readonly GhostReaderFactory _ghostReaderFactory;
     private readonly HttpClient _httpClient;
     private readonly SemaphoreSlim _downloadSlots = new(MaxConcurrentDownloads, MaxConcurrentDownloads);
+    private readonly SemaphoreSlim _parseSlots = new(4, 4);
     private readonly Dictionary<int, Task<Result<IGhost>>> _downloads = new();
     private readonly object _downloadsLock = new();
 
@@ -40,8 +41,9 @@ public class GhostRepository
         string ghostUrl,
         CancellationToken cancellationToken = default)
     {
-        if (TryGetGhostFromDisk(recordId, out IGhost ghost))
-            return Result.Ok(ghost);
+        IGhost cachedGhost = await ReadGhostFromDiskAsync(recordId, cancellationToken);
+        if (cachedGhost != null)
+            return Result.Ok(cachedGhost);
 
         Task<Result<IGhost>> download;
         lock (_downloadsLock)
@@ -90,7 +92,7 @@ public class GhostRepository
 
             byte[] buffer = await ReadLimitedAsync(response.Content, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
-            IGhost downloadedGhost = ReadGhost(buffer);
+            IGhost downloadedGhost = await ParseGhostAsync(buffer, cancellationToken);
             _modStorage.WriteBlob(GetStorageKey(recordId), buffer);
             return Result.Ok(downloadedGhost);
         }
@@ -108,26 +110,50 @@ public class GhostRepository
         }
     }
 
-    private bool TryGetGhostFromDisk(int recordId, out IGhost ghost)
+    private async Task<IGhost> ReadGhostFromDiskAsync(int recordId, CancellationToken cancellationToken)
     {
-        string storageKey = GetStorageKey(recordId);
-        if (!_modStorage.BlobFileExists(storageKey))
-        {
-            ghost = null;
-            return false;
-        }
-
+        await _parseSlots.WaitAsync(cancellationToken);
         try
         {
-            byte[] buffer = _modStorage.ReadBlob(storageKey);
-            ghost = ReadGhost(buffer);
-            return true;
+            return await Task.Run(() =>
+            {
+                string storageKey = GetStorageKey(recordId);
+                if (!_modStorage.BlobFileExists(storageKey))
+                    return null;
+
+                try
+                {
+                    byte[] buffer = _modStorage.ReadBlob(storageKey);
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return ReadGhost(buffer);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch
+                {
+                    _modStorage.DeleteBlob(storageKey);
+                    return null;
+                }
+            }, cancellationToken);
         }
-        catch
+        finally
         {
-            _modStorage.DeleteBlob(storageKey);
-            ghost = null;
-            return false;
+            _parseSlots.Release();
+        }
+    }
+
+    private async Task<IGhost> ParseGhostAsync(byte[] buffer, CancellationToken cancellationToken)
+    {
+        await _parseSlots.WaitAsync(cancellationToken);
+        try
+        {
+            return await Task.Run(() => ReadGhost(buffer), cancellationToken);
+        }
+        finally
+        {
+            _parseSlots.Release();
         }
     }
 

--- a/Ghosting/Playback/GhostVisibilityService.cs
+++ b/Ghosting/Playback/GhostVisibilityService.cs
@@ -59,7 +59,7 @@ public class GhostVisibilityService : IEagerService
             return;
         }
 
-        ghostData.Visuals.gameObject.SetActive(_configService.ShowGhosts.Value);
+        ghostData.SetActive(_configService.ShowGhosts.Value);
 
         if (!_configService.ShowGhosts.Value)
         {
@@ -72,7 +72,7 @@ public class GhostVisibilityService : IEagerService
             _ => throw new ArgumentOutOfRangeException()
         };
 
-        ghostData.Visuals.gameObject.SetActive(configEntry.Value);
+        ghostData.SetActive(configEntry.Value);
     }
 
     private void OnUpdate()

--- a/Ghosting/Playback/GhostVisuals.cs
+++ b/Ghosting/Playback/GhostVisuals.cs
@@ -49,18 +49,29 @@ public class GhostVisuals : MonoBehaviour
 
     private void ConfigureBulkVisuals()
     {
-        Cosmetics = GetBulkCosmetics();
-
-        GhostModel.DoCarSetup(Cosmetics, true, true, false);
-        GhostModel.DisableParaglider();
+        Cosmetics = ConfigureBulkModel(GhostModel);
         HornHolder.SetActive(false);
+    }
 
-        foreach (Ghost_AnimateWheel_v16 wheel in Wheels)
+    public static CosmeticsV16 ConfigureBulkModel(SetupModelCar model)
+    {
+        CosmeticsV16 cosmetics = GetBulkCosmetics();
+        model.DoCarSetup(cosmetics, true, true, false);
+        model.DisableParaglider();
+
+        foreach (Ghost_AnimateWheel_v16 wheel in model.GetComponentsInChildren<Ghost_AnimateWheel_v16>())
         {
+            wheel.enabled = false;
             wheel.offroadWheelModel.gameObject.SetActive(false);
             wheel.soapwheelModel.gameObject.SetActive(false);
             wheel.wheelModel.gameObject.SetActive(true);
         }
+
+        GameObject hornHolder = model.transform.Find("Visible Horn")?.gameObject;
+        if (hornHolder != null)
+            hornHolder.SetActive(false);
+
+        return cosmetics;
     }
 
     private static CosmeticsV16 GetBulkCosmetics()

--- a/Ghosting/Playback/OfflineGhostsService.cs
+++ b/Ghosting/Playback/OfflineGhostsService.cs
@@ -1,13 +1,14 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using TNRD.Zeepkist.GTR.Configuration;
 using TNRD.Zeepkist.GTR.Core;
 using TNRD.Zeepkist.GTR.Ghosting.Ghosts;
-using TNRD.Zeepkist.GTR.Messaging;
 using TNRD.Zeepkist.GTR.PlayerLoop;
-using UnityEngine;
 using ZeepSDK.External.Cysharp.Threading.Tasks;
 using ZeepSDK.External.FluentResults;
 using ZeepSDK.Level;
@@ -16,25 +17,28 @@ using ZeepSDK.Racing;
 
 namespace TNRD.Zeepkist.GTR.Ghosting.Playback;
 
-public class OfflineGhostsService : IEagerService, System.IDisposable
+public class OfflineGhostsService : IEagerService, IDisposable
 {
     private readonly ILogger<OfflineGhostsService> _logger;
     private readonly OfflineGhostGraphqlService _graphqlService;
     private readonly GhostRepository _ghostRepository;
     private readonly GhostPlayer _ghostPlayer;
     private readonly ConfigService _configService;
-    private readonly MessengerService _messengerService;
     private readonly PlayerLoopService _playerLoopService;
     private readonly PlayerLoopSubscription _updateSubscription;
+    private readonly BulkGhostModeState _bulkModeState;
 
     private readonly List<string> _additionalGhosts = new();
     private readonly HashSet<int> _bulkGhostIds = new();
+    private readonly ConcurrentQueue<PendingGhostOperation> _pendingOperations = new();
 
     private CancellationTokenSource _cts;
     private string _bulkLevelHash;
+    private string _loadedLevelHash;
+    private int _loadGeneration;
 
     public bool IsShowingAllGhosts { get; private set; }
-    public event System.Action BulkModeChanged;
+    public event Action BulkModeChanged;
 
     public OfflineGhostsService(
         ILogger<OfflineGhostsService> logger,
@@ -43,52 +47,49 @@ public class OfflineGhostsService : IEagerService, System.IDisposable
         GhostPlayer ghostPlayer,
         ConfigService configService,
         PlayerLoopService playerLoopService,
-        MessengerService messengerService)
+        BulkGhostModeState bulkModeState)
     {
         _logger = logger;
         _graphqlService = graphqlService;
         _ghostRepository = ghostRepository;
         _ghostPlayer = ghostPlayer;
         _configService = configService;
-        _messengerService = messengerService;
         _playerLoopService = playerLoopService;
+        _bulkModeState = bulkModeState;
 
         _updateSubscription = playerLoopService.SubscribeUpdate(OnUpdate);
-
         RacingApi.PlayerSpawned += OnPlayerSpawned;
         RacingApi.RoundEnded += OnRoundEnded;
         RacingApi.Quit += OnQuit;
-        // TODO: Figure out when quitting to main menu
-        // TODO: Figure out when pause menu opened
     }
 
     private void OnUpdate()
     {
+        DrainPendingOperations();
+
         if (MultiplayerApi.IsPlayingOnline)
             return;
-
-        if (PlayerManager.Instance == null) return;
-        if (PlayerManager.Instance.currentMaster == null) return;
-        if (PlayerManager.Instance.currentMaster.OnlineGameplayUI == null) return;
+        if (PlayerManager.Instance == null ||
+            PlayerManager.Instance.currentMaster == null ||
+            PlayerManager.Instance.currentMaster.OnlineGameplayUI == null)
+        {
+            return;
+        }
 
         if (PlayerManager.Instance.currentMaster.OnlineGameplayUI.LeaderboardAction.buttonDown)
-        {
             PlayerManager.Instance.currentMaster.OnlineGameplayUI.OnlineTabLeaderboard.Open(true);
-        }
     }
 
     protected virtual void OnPlayerSpawned()
     {
-        if (MultiplayerApi.IsPlayingOnline)
+        if (MultiplayerApi.IsPlayingOnline || !_configService.EnableGhosts.Value)
             return;
 
-        if (_configService.EnableGhosts.Value)
-        {
-            if (IsShowingAllGhosts && _bulkLevelHash == LevelApi.CurrentHash)
-                LoadAllGhosts();
-            else
-                ClearAllGhosts();
-        }
+        PrepareLevel();
+        if (IsShowingAllGhosts && _bulkLevelHash == LevelApi.CurrentHash)
+            LoadAllGhosts();
+        else
+            LoadGhosts();
     }
 
     private void OnQuit()
@@ -98,65 +99,55 @@ public class OfflineGhostsService : IEagerService, System.IDisposable
 
         CancelLoad();
         SetBulkMode(false);
+        _loadedLevelHash = null;
+        _bulkLevelHash = null;
+        _bulkGhostIds.Clear();
         _ghostPlayer.ClearGhosts();
     }
 
-    private void OnRoundEnded()
+    private static void OnRoundEnded()
     {
-        if (MultiplayerApi.IsPlayingOnline)
-            return;
-
-        CancelLoad();
-        _ghostPlayer.ClearGhosts();
+        // Keep same-level ghosts loaded. GhostPlayer resets playback state.
     }
 
     private void LoadGhosts()
     {
-        CancelLoad();
-        _cts = new CancellationTokenSource();
-        LoadGhostsAsync(_cts.Token).Forget();
+        (CancellationToken token, int generation) = BeginLoad();
+        LoadGhostsAsync(token, generation).Forget();
     }
 
-    private async UniTaskVoid LoadGhostsAsync(CancellationToken ct)
+    private async UniTaskVoid LoadGhostsAsync(CancellationToken ct, int generation)
     {
-        (Result<IReadOnlyList<IGetPersonalBestGhosts_PersonalBestGlobals_Nodes>> pbResult,
-                Result<IReadOnlyList<IGetAdditionalGhosts_PersonalBestGlobals_Nodes>> additionalResult) =
-            await UniTask.WhenAll(
-                LoadPersonalBestsAsync(ct),
-                LoadAdditionalGhostsAsync(ct));
+        (
+            Result<IReadOnlyList<IGetPersonalBestGhosts_PersonalBestGlobals_Nodes>> pbResult,
+            Result<IReadOnlyList<IGetAdditionalGhosts_PersonalBestGlobals_Nodes>> additionalResult
+        ) = await UniTask.WhenAll(
+            LoadPersonalBestsAsync(ct),
+            LoadAdditionalGhostsAsync(ct));
 
-        List<IGhostRecordFrag> personalBests = new();
+        if (ct.IsCancellationRequested ||
+            !GhostLoadBudget.IsCurrentGeneration(generation, Volatile.Read(ref _loadGeneration)))
+            return;
 
+        var records = new List<IGhostRecordFrag>();
         if (pbResult.IsSuccess)
-        {
-            personalBests.AddRange(pbResult.Value.Select(x => x.Record));
-        }
+            records.AddRange(pbResult.Value.Select(x => x.Record));
         else
-        {
             _logger.LogWarning("Loading Personal Bests failed: {Result}", pbResult);
-        }
 
         if (additionalResult.IsSuccess)
-        {
-            personalBests.AddRange(additionalResult.Value.Select(x => x.Record));
-        }
+            records.AddRange(additionalResult.Value.Select(x => x.Record));
         else
-        {
             _logger.LogWarning("Loading AdditionalGhosts failed: {Result}", additionalResult);
-        }
 
-        IReadOnlyList<int> loadedGhostIds = _ghostPlayer.GetLoadedGhostIds();
+        List<IGhostRecordFrag> distinctRecords = records
+            .GroupBy(record => record.Id)
+            .Select(group => group.First())
+            .ToList();
+        var desiredIds = distinctRecords.Select(record => record.Id).ToHashSet();
 
-        foreach (int loadedGhostId in loadedGhostIds)
-        {
-            if (personalBests.All(x => x.Id != loadedGhostId))
-            {
-                _ghostPlayer.RemoveGhost(loadedGhostId);
-            }
-        }
-
-        IEnumerable<UniTask> loads = personalBests.Select(personalBest => LoadGhost(personalBest, ct));
-        await UniTask.WhenAll(loads);
+        await LoadRecords(distinctRecords, GhostVisualProfile.Full, ct, generation);
+        EnqueueReconciliation(desiredIds, generation);
     }
 
     public void ShowAllGhosts()
@@ -164,6 +155,7 @@ public class OfflineGhostsService : IEagerService, System.IDisposable
         if (IsShowingAllGhosts)
             return;
 
+        PrepareLevel();
         _bulkLevelHash = LevelApi.CurrentHash;
         SetBulkMode(true);
         LoadAllGhosts();
@@ -183,12 +175,11 @@ public class OfflineGhostsService : IEagerService, System.IDisposable
 
     private void LoadAllGhosts()
     {
-        CancelLoad();
-        _cts = new CancellationTokenSource();
-        LoadAllGhostsAsync(_cts.Token).Forget();
+        (CancellationToken token, int generation) = BeginLoad();
+        LoadAllGhostsAsync(token, generation).Forget();
     }
 
-    private async UniTaskVoid LoadAllGhostsAsync(CancellationToken ct)
+    private async UniTaskVoid LoadAllGhostsAsync(CancellationToken ct, int generation)
     {
         int? first = OfflineGhostLimit.ToGraphQlFirst(_configService.MaximumVisibleOfflineGhosts.Value);
         (
@@ -200,10 +191,14 @@ public class OfflineGhostsService : IEagerService, System.IDisposable
             LoadAdditionalGhostsAsync(ct),
             _graphqlService.GetAllPersonalBestGhosts(LevelApi.CurrentHash, first, ct));
 
-        if (ct.IsCancellationRequested || !IsShowingAllGhosts)
+        if (ct.IsCancellationRequested ||
+            !GhostLoadBudget.IsCurrentGeneration(generation, Volatile.Read(ref _loadGeneration)) ||
+            !IsShowingAllGhosts)
+        {
             return;
+        }
 
-        List<IGhostRecordFrag> protectedGhosts = new();
+        var protectedGhosts = new List<IGhostRecordFrag>();
         if (pbResult.IsSuccess)
             protectedGhosts.AddRange(pbResult.Value.Select(x => x.Record));
         else
@@ -224,54 +219,49 @@ public class OfflineGhostsService : IEagerService, System.IDisposable
         foreach (IGetAllPersonalBestGhosts_Records_Nodes record in bulkGhosts)
             _bulkGhostIds.Add(record.Id);
 
-        HashSet<int> protectedGhostIds = protectedGhosts.Select(x => x.Id).ToHashSet();
-        HashSet<int> desiredIds = protectedGhostIds.ToHashSet();
-        desiredIds.UnionWith(_bulkGhostIds);
-        foreach (int loadedGhostId in _ghostPlayer.GetLoadedGhostIds())
-        {
-            if (!desiredIds.Contains(loadedGhostId))
-                _ghostPlayer.RemoveGhost(loadedGhostId);
-        }
-
-        IEnumerable<IGhostRecordFrag> recordsToLoad = protectedGhosts
-            .Concat(bulkGhosts)
+        List<IGhostRecordFrag> distinctProtected = protectedGhosts
             .GroupBy(record => record.Id)
-            .Select(group => group.First());
-        await UniTask.WhenAll(recordsToLoad.Select(record => LoadGhost(
-            record,
-            ct,
-            GhostVisualProfileResolver.Resolve(record.Id, protectedGhostIds, _bulkGhostIds))));
+            .Select(group => group.First())
+            .ToList();
+        HashSet<int> protectedIds = distinctProtected.Select(record => record.Id).ToHashSet();
+
+        var distinctBulk = bulkGhosts
+            .Where(record => !protectedIds.Contains(record.Id))
+            .GroupBy(record => record.Id)
+            .Select(group => (IGhostRecordFrag)group.First())
+            .ToList();
+
+        var desiredIds = protectedIds.ToHashSet();
+        desiredIds.UnionWith(_bulkGhostIds);
+
+        await LoadRecords(distinctProtected, GhostVisualProfile.Full, ct, generation);
+        await LoadRecords(distinctBulk, GhostVisualProfile.Bulk, ct, generation);
+        EnqueueReconciliation(desiredIds, generation);
     }
 
     private async UniTask<Result<IReadOnlyList<IGetPersonalBestGhosts_PersonalBestGlobals_Nodes>>>
-        LoadPersonalBestsAsync(
-        CancellationToken ct)
+        LoadPersonalBestsAsync(CancellationToken ct)
     {
-        Result<IReadOnlyList<IGetPersonalBestGhosts_PersonalBestGlobals_Nodes>> result
-            = await _graphqlService.GetPersonalBests(LevelApi.CurrentHash, ct);
+        Result<IReadOnlyList<IGetPersonalBestGhosts_PersonalBestGlobals_Nodes>> result =
+            await _graphqlService.GetPersonalBests(LevelApi.CurrentHash, ct);
 
         if (ct.IsCancellationRequested)
             return Result.Ok();
-
         if (result.IsFailed)
             _logger.LogError("Failed to load personal bests: {Result}", result);
-
         return result;
     }
 
     private async UniTask<Result<IReadOnlyList<IGetAdditionalGhosts_PersonalBestGlobals_Nodes>>>
-        LoadAdditionalGhostsAsync(
-        CancellationToken ct)
+        LoadAdditionalGhostsAsync(CancellationToken ct)
     {
-        Result<IReadOnlyList<IGetAdditionalGhosts_PersonalBestGlobals_Nodes>> result
-            = await _graphqlService.GetAdditionalGhosts(_additionalGhosts, LevelApi.CurrentHash, ct);
+        Result<IReadOnlyList<IGetAdditionalGhosts_PersonalBestGlobals_Nodes>> result =
+            await _graphqlService.GetAdditionalGhosts(_additionalGhosts, LevelApi.CurrentHash, ct);
 
         if (ct.IsCancellationRequested)
             return Result.Ok();
-
         if (result.IsFailed)
             _logger.LogError("Failed to load additional ghosts: {Result}", result);
-
         return result;
     }
 
@@ -279,49 +269,73 @@ public class OfflineGhostsService : IEagerService, System.IDisposable
     {
         if (IsShowingAllGhosts)
             return;
+
         _additionalGhosts.Add(steamId);
-        _ghostPlayer.ClearGhosts();
         LoadGhosts();
     }
 
-    public bool ContainsAdditionalGhost(string steamId)
-    {
-        return _additionalGhosts.Contains(steamId);
-    }
+    public bool ContainsAdditionalGhost(string steamId) => _additionalGhosts.Contains(steamId);
 
     public void RemoveAdditionalGhost(string steamId)
     {
         if (IsShowingAllGhosts)
             return;
+
         _additionalGhosts.Remove(steamId);
-        _ghostPlayer.ClearGhosts();
         LoadGhosts();
     }
 
-    private async UniTask LoadGhost(
-        IGhostRecordFrag personalBest,
+    private async UniTask LoadRecords(
+        IReadOnlyCollection<IGhostRecordFrag> records,
+        GhostVisualProfile visualProfile,
         CancellationToken cancellationToken,
-        GhostVisualProfile visualProfile = GhostVisualProfile.Full)
+        int generation)
     {
-        Result<IGhost> ghost = await _ghostRepository.GetGhost(
-            personalBest.Id,
-            personalBest.RecordMedia.GhostUrl,
-            cancellationToken);
+        IEnumerable<UniTask> loads = records.Select(record =>
+            LoadGhost(record, cancellationToken, visualProfile, generation));
+        await UniTask.WhenAll(loads);
+    }
 
-        if (cancellationToken.IsCancellationRequested)
+    private async UniTask LoadGhost(
+        IGhostRecordFrag record,
+        CancellationToken cancellationToken,
+        GhostVisualProfile visualProfile,
+        int generation)
+    {
+        if (_ghostPlayer.HasGhost(record.Id, visualProfile))
             return;
+
+        Result<IGhost> ghost;
+        try
+        {
+            ghost = await _ghostRepository.GetGhost(
+                record.Id,
+                record.RecordMedia.GhostUrl,
+                cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+
+        if (cancellationToken.IsCancellationRequested ||
+            !GhostLoadBudget.IsCurrentGeneration(generation, Volatile.Read(ref _loadGeneration)))
+        {
+            return;
+        }
+
         if (ghost.IsFailed)
         {
             _logger.LogError("Unable to get ghost from repository: {Result}", ghost.ToString());
             return;
         }
 
-        _ghostPlayer.AddGhost(
-            GhostType.Global,
-            personalBest.Id,
-            personalBest.User.SteamName,
+        _pendingOperations.Enqueue(PendingGhostOperation.Add(
+            generation,
+            record.Id,
+            record.User.SteamName,
             ghost.Value,
-            visualProfile);
+            visualProfile));
     }
 
     private void SetBulkMode(bool enabled)
@@ -330,26 +344,152 @@ public class OfflineGhostsService : IEagerService, System.IDisposable
             return;
 
         IsShowingAllGhosts = enabled;
+        _bulkModeState.SetActive(enabled);
         BulkModeChanged?.Invoke();
+    }
+
+    private (CancellationToken Token, int Generation) BeginLoad()
+    {
+        CancelLoad();
+        _cts = new CancellationTokenSource();
+        return (_cts.Token, Volatile.Read(ref _loadGeneration));
     }
 
     private void CancelLoad()
     {
+        Interlocked.Increment(ref _loadGeneration);
+        while (_pendingOperations.TryDequeue(out _))
+        {
+        }
+
         CancellationTokenSource cts = _cts;
         _cts = null;
         if (cts == null)
             return;
+
         cts.Cancel();
         cts.Dispose();
+    }
+
+    private void PrepareLevel()
+    {
+        string currentLevelHash = LevelApi.CurrentHash;
+        if (_loadedLevelHash == currentLevelHash)
+            return;
+
+        CancelLoad();
+        _ghostPlayer.ClearGhosts();
+        _loadedLevelHash = currentLevelHash;
+    }
+
+    private void EnqueueReconciliation(HashSet<int> desiredIds, int generation)
+    {
+        if (GhostLoadBudget.IsCurrentGeneration(generation, Volatile.Read(ref _loadGeneration)))
+            _pendingOperations.Enqueue(PendingGhostOperation.Reconcile(generation, desiredIds));
+    }
+
+    private void DrainPendingOperations()
+    {
+        int processed = 0;
+        long startedAt = Stopwatch.GetTimestamp();
+        while (GhostLoadBudget.CanProcessNext(processed, GetElapsedMilliseconds(startedAt)) &&
+               _pendingOperations.TryDequeue(out PendingGhostOperation operation))
+        {
+            if (!GhostLoadBudget.IsCurrentGeneration(
+                    operation.Generation,
+                    Volatile.Read(ref _loadGeneration)))
+            {
+                continue;
+            }
+
+            if (operation.DesiredIds != null)
+            {
+                IReadOnlyList<int> obsoleteIds = GhostReconciliation.GetObsoleteIds(
+                    _ghostPlayer.GetLoadedGhostIds(),
+                    operation.DesiredIds);
+                foreach (int loadedGhostId in obsoleteIds)
+                {
+                    _pendingOperations.Enqueue(
+                        PendingGhostOperation.Remove(operation.Generation, loadedGhostId));
+                }
+            }
+            else if (operation.RemoveRecordId.HasValue)
+            {
+                _ghostPlayer.RemoveGhost(operation.RemoveRecordId.Value);
+            }
+            else
+            {
+                _ghostPlayer.AddGhost(
+                    GhostType.Global,
+                    operation.RecordId,
+                    operation.SteamName,
+                    operation.Ghost,
+                    operation.VisualProfile);
+            }
+
+            processed++;
+        }
+    }
+
+    private static double GetElapsedMilliseconds(long startedAt)
+    {
+        return (Stopwatch.GetTimestamp() - startedAt) * 1000d / Stopwatch.Frequency;
     }
 
     public void Dispose()
     {
         CancelLoad();
+        SetBulkMode(false);
         BulkModeChanged = null;
         _playerLoopService.UnsubscribeUpdate(_updateSubscription);
         RacingApi.PlayerSpawned -= OnPlayerSpawned;
         RacingApi.RoundEnded -= OnRoundEnded;
         RacingApi.Quit -= OnQuit;
+    }
+
+    private sealed class PendingGhostOperation
+    {
+        public int Generation { get; private set; }
+        public int RecordId { get; private set; }
+        public string SteamName { get; private set; }
+        public IGhost Ghost { get; private set; }
+        public GhostVisualProfile VisualProfile { get; private set; }
+        public HashSet<int> DesiredIds { get; private set; }
+        public int? RemoveRecordId { get; private set; }
+
+        public static PendingGhostOperation Add(
+            int generation,
+            int recordId,
+            string steamName,
+            IGhost ghost,
+            GhostVisualProfile visualProfile)
+        {
+            return new PendingGhostOperation
+            {
+                Generation = generation,
+                RecordId = recordId,
+                SteamName = steamName,
+                Ghost = ghost,
+                VisualProfile = visualProfile
+            };
+        }
+
+        public static PendingGhostOperation Reconcile(int generation, HashSet<int> desiredIds)
+        {
+            return new PendingGhostOperation
+            {
+                Generation = generation,
+                DesiredIds = desiredIds
+            };
+        }
+
+        public static PendingGhostOperation Remove(int generation, int recordId)
+        {
+            return new PendingGhostOperation
+            {
+                Generation = generation,
+                RemoveRecordId = recordId
+            };
+        }
     }
 }

--- a/Ghosting/Playback/OfflineGhostsService.cs
+++ b/Ghosting/Playback/OfflineGhostsService.cs
@@ -331,6 +331,15 @@ public class OfflineGhostsService : IEagerService, IDisposable
         {
             return;
         }
+        catch (Exception exception)
+        {
+            _logger.LogError(
+                exception,
+                "Unable to download or parse ghost {RecordId}",
+                record.Id);
+            CompleteProgressRecord(generation, false);
+            return;
+        }
 
         if (cancellationToken.IsCancellationRequested ||
             !GhostLoadBudget.IsCurrentGeneration(generation, Volatile.Read(ref _loadGeneration)))
@@ -435,13 +444,24 @@ public class OfflineGhostsService : IEagerService, IDisposable
             }
             else
             {
-                _ghostPlayer.AddGhost(
-                    GhostType.Global,
-                    operation.RecordId,
-                    operation.SteamName,
-                    operation.Ghost,
-                    operation.VisualProfile);
-                CompleteProgressRecord(operation.Generation, true);
+                try
+                {
+                    _ghostPlayer.AddGhost(
+                        GhostType.Global,
+                        operation.RecordId,
+                        operation.SteamName,
+                        operation.Ghost,
+                        operation.VisualProfile);
+                    CompleteProgressRecord(operation.Generation, true);
+                }
+                catch (Exception exception)
+                {
+                    _logger.LogError(
+                        exception,
+                        "Unable to add ghost {RecordId}",
+                        operation.RecordId);
+                    CompleteProgressRecord(operation.Generation, false);
+                }
             }
 
             processed++;
@@ -496,9 +516,17 @@ public class OfflineGhostsService : IEagerService, IDisposable
 
         _progressActive = false;
         if (loaded == total)
-            _messengerService.LogSuccess($"Loaded {loaded} ghosts");
+        {
+            _messengerService.LogSuccess(
+                $"Loading ghosts: 100% ({loaded}/{total})",
+                2);
+        }
         else
-            _messengerService.LogWarning($"Loaded {loaded}/{total} ghosts");
+        {
+            _messengerService.LogWarning(
+                $"Loading ghosts: 100% ({loaded}/{total})",
+                2);
+        }
     }
 
     public void Dispose()

--- a/Ghosting/Playback/OfflineGhostsService.cs
+++ b/Ghosting/Playback/OfflineGhostsService.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging;
 using TNRD.Zeepkist.GTR.Configuration;
 using TNRD.Zeepkist.GTR.Core;
 using TNRD.Zeepkist.GTR.Ghosting.Ghosts;
+using TNRD.Zeepkist.GTR.Messaging;
 using TNRD.Zeepkist.GTR.PlayerLoop;
 using ZeepSDK.External.Cysharp.Threading.Tasks;
 using ZeepSDK.External.FluentResults;
@@ -27,6 +28,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
     private readonly PlayerLoopService _playerLoopService;
     private readonly PlayerLoopSubscription _updateSubscription;
     private readonly BulkGhostModeState _bulkModeState;
+    private readonly MessengerService _messengerService;
 
     private readonly List<string> _additionalGhosts = new();
     private readonly HashSet<int> _bulkGhostIds = new();
@@ -36,6 +38,12 @@ public class OfflineGhostsService : IEagerService, IDisposable
     private string _bulkLevelHash;
     private string _loadedLevelHash;
     private int _loadGeneration;
+    private int _progressGeneration;
+    private int _progressTotal;
+    private int _progressCompleted;
+    private int _progressLoaded;
+    private int _lastReportedProgress;
+    private bool _progressActive;
 
     public bool IsShowingAllGhosts { get; private set; }
     public event Action BulkModeChanged;
@@ -47,6 +55,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
         GhostPlayer ghostPlayer,
         ConfigService configService,
         PlayerLoopService playerLoopService,
+        MessengerService messengerService,
         BulkGhostModeState bulkModeState)
     {
         _logger = logger;
@@ -55,6 +64,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
         _ghostPlayer = ghostPlayer;
         _configService = configService;
         _playerLoopService = playerLoopService;
+        _messengerService = messengerService;
         _bulkModeState = bulkModeState;
 
         _updateSubscription = playerLoopService.SubscribeUpdate(OnUpdate);
@@ -66,6 +76,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
     private void OnUpdate()
     {
         DrainPendingOperations();
+        UpdateLoadProgress();
 
         if (MultiplayerApi.IsPlayingOnline)
             return;
@@ -234,6 +245,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
         var desiredIds = protectedIds.ToHashSet();
         desiredIds.UnionWith(_bulkGhostIds);
 
+        BeginProgress(generation, distinctProtected.Count + distinctBulk.Count);
         await LoadRecords(distinctProtected, GhostVisualProfile.Full, ct, generation);
         await LoadRecords(distinctBulk, GhostVisualProfile.Bulk, ct, generation);
         EnqueueReconciliation(desiredIds, generation);
@@ -303,7 +315,10 @@ public class OfflineGhostsService : IEagerService, IDisposable
         int generation)
     {
         if (_ghostPlayer.HasGhost(record.Id, visualProfile))
+        {
+            CompleteProgressRecord(generation, true);
             return;
+        }
 
         Result<IGhost> ghost;
         try
@@ -327,6 +342,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
         if (ghost.IsFailed)
         {
             _logger.LogError("Unable to get ghost from repository: {Result}", ghost.ToString());
+            CompleteProgressRecord(generation, false);
             return;
         }
 
@@ -358,6 +374,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
     private void CancelLoad()
     {
         Interlocked.Increment(ref _loadGeneration);
+        _progressActive = false;
         while (_pendingOperations.TryDequeue(out _))
         {
         }
@@ -425,6 +442,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
                     operation.SteamName,
                     operation.Ghost,
                     operation.VisualProfile);
+                CompleteProgressRecord(operation.Generation, true);
             }
 
             processed++;
@@ -434,6 +452,58 @@ public class OfflineGhostsService : IEagerService, IDisposable
     private static double GetElapsedMilliseconds(long startedAt)
     {
         return (Stopwatch.GetTimestamp() - startedAt) * 1000d / Stopwatch.Frequency;
+    }
+
+    private void BeginProgress(int generation, int total)
+    {
+        Volatile.Write(ref _progressGeneration, generation);
+        Volatile.Write(ref _progressTotal, total);
+        Volatile.Write(ref _progressCompleted, 0);
+        Volatile.Write(ref _progressLoaded, 0);
+        _lastReportedProgress = -GhostLoadProgress.ReportStepPercent;
+        _progressActive = true;
+    }
+
+    private void CompleteProgressRecord(int generation, bool loaded)
+    {
+        if (!GhostLoadBudget.IsCurrentGeneration(
+                generation,
+                Volatile.Read(ref _progressGeneration)))
+        {
+            return;
+        }
+
+        if (loaded)
+            Interlocked.Increment(ref _progressLoaded);
+        Interlocked.Increment(ref _progressCompleted);
+    }
+
+    private void UpdateLoadProgress()
+    {
+        if (!_progressActive)
+            return;
+
+        int total = Volatile.Read(ref _progressTotal);
+        int completed = Volatile.Read(ref _progressCompleted);
+        int percent = GhostLoadProgress.CalculatePercent(completed, total);
+        if (!GhostLoadProgress.ShouldReport(percent, _lastReportedProgress))
+            return;
+
+        _lastReportedProgress = percent;
+        int loaded = Volatile.Read(ref _progressLoaded);
+        if (percent < 100)
+        {
+            _messengerService.Log(
+                $"Loading ghosts: {percent}% ({loaded}/{total})",
+                1.5f);
+            return;
+        }
+
+        _progressActive = false;
+        if (loaded == total)
+            _messengerService.LogSuccess($"Loaded {loaded} ghosts");
+        else
+            _messengerService.LogWarning($"Loaded {loaded}/{total} ghosts");
     }
 
     public void Dispose()

--- a/Ghosting/Playback/OfflineGhostsService.cs
+++ b/Ghosting/Playback/OfflineGhostsService.cs
@@ -42,7 +42,6 @@ public class OfflineGhostsService : IEagerService, IDisposable
     private int _progressTotal;
     private int _progressCompleted;
     private int _progressLoaded;
-    private int _lastReportedProgress;
     private bool _progressActive;
 
     public bool IsShowingAllGhosts { get; private set; }
@@ -460,7 +459,6 @@ public class OfflineGhostsService : IEagerService, IDisposable
         Volatile.Write(ref _progressTotal, total);
         Volatile.Write(ref _progressCompleted, 0);
         Volatile.Write(ref _progressLoaded, 0);
-        _lastReportedProgress = -GhostLoadProgress.ReportStepPercent;
         _progressActive = true;
     }
 
@@ -486,10 +484,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
         int total = Volatile.Read(ref _progressTotal);
         int completed = Volatile.Read(ref _progressCompleted);
         int percent = GhostLoadProgress.CalculatePercent(completed, total);
-        if (!GhostLoadProgress.ShouldReport(percent, _lastReportedProgress))
-            return;
 
-        _lastReportedProgress = percent;
         int loaded = Volatile.Read(ref _progressLoaded);
         if (percent < 100)
         {

--- a/Ghosting/Playback/OfflineGhostsService.cs
+++ b/Ghosting/Playback/OfflineGhostsService.cs
@@ -42,6 +42,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
     private int _progressTotal;
     private int _progressCompleted;
     private int _progressLoaded;
+    private int _lastReportedProgressCompleted;
     private bool _progressActive;
 
     public bool IsShowingAllGhosts { get; private set; }
@@ -479,6 +480,7 @@ public class OfflineGhostsService : IEagerService, IDisposable
         Volatile.Write(ref _progressTotal, total);
         Volatile.Write(ref _progressCompleted, 0);
         Volatile.Write(ref _progressLoaded, 0);
+        _lastReportedProgressCompleted = 0;
         _progressActive = true;
     }
 
@@ -503,6 +505,10 @@ public class OfflineGhostsService : IEagerService, IDisposable
 
         int total = Volatile.Read(ref _progressTotal);
         int completed = Volatile.Read(ref _progressCompleted);
+        if (!GhostLoadProgress.HasAdvanced(completed, _lastReportedProgressCompleted))
+            return;
+
+        _lastReportedProgressCompleted = completed;
         int percent = GhostLoadProgress.CalculatePercent(completed, total);
 
         int loaded = Volatile.Read(ref _progressLoaded);

--- a/PlayerLoop/PlayerLoopService.PlayerLoopBehaviour.cs
+++ b/PlayerLoop/PlayerLoopService.PlayerLoopBehaviour.cs
@@ -12,9 +12,11 @@ public partial class PlayerLoopService
     {
         private readonly Dictionary<PlayerLoopSubscription, Action> _updates = new();
         private readonly Dictionary<PlayerLoopSubscription, Action> _fixedUpdates = new();
+        private readonly Dictionary<PlayerLoopSubscription, Action> _lateUpdates = new();
 
         private readonly HashSet<PlayerLoopSubscription> _updatesToRemove = new();
         private readonly HashSet<PlayerLoopSubscription> _fixedUpdatesToRemove = new();
+        private readonly HashSet<PlayerLoopSubscription> _lateUpdatesToRemove = new();
 
         private ILogger _logger;
 
@@ -54,6 +56,24 @@ public partial class PlayerLoopService
             _fixedUpdatesToRemove.Add(subscription);
         }
 
+        public PlayerLoopSubscription SubscribeLateUpdate(Action action)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
+            PlayerLoopSubscription subscription = new();
+            _lateUpdates.Add(subscription, action);
+            return subscription;
+        }
+
+        public void UnsubscribeLateUpdate(PlayerLoopSubscription subscription)
+        {
+            if (subscription == null)
+                throw new ArgumentNullException(nameof(subscription));
+
+            _lateUpdatesToRemove.Add(subscription);
+        }
+
         private void Update()
         {
             foreach (PlayerLoopSubscription subscription in _updatesToRemove)
@@ -87,6 +107,27 @@ public partial class PlayerLoopService
             _fixedUpdatesToRemove.Clear();
 
             foreach (KeyValuePair<PlayerLoopSubscription, Action> kvp in _fixedUpdates)
+            {
+                try
+                {
+                    kvp.Value();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                    throw;
+                }
+            }
+        }
+
+        private void LateUpdate()
+        {
+            foreach (PlayerLoopSubscription subscription in _lateUpdatesToRemove)
+                _lateUpdates.Remove(subscription);
+
+            _lateUpdatesToRemove.Clear();
+
+            foreach (KeyValuePair<PlayerLoopSubscription, Action> kvp in _lateUpdates)
             {
                 try
                 {

--- a/PlayerLoop/PlayerLoopService.cs
+++ b/PlayerLoop/PlayerLoopService.cs
@@ -40,6 +40,16 @@ public partial class PlayerLoopService : IEagerService, IDisposable
         _behaviour.UnsubscribeFixedUpdate(subscription);
     }
 
+    public PlayerLoopSubscription SubscribeLateUpdate(Action action)
+    {
+        return _behaviour.SubscribeLateUpdate(action);
+    }
+
+    public void UnsubscribeLateUpdate(PlayerLoopSubscription subscription)
+    {
+        _behaviour.UnsubscribeLateUpdate(subscription);
+    }
+
     public void Dispose()
     {
         if (_behaviour != null)

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -96,6 +96,7 @@ public class Plugin : BaseUnityPlugin
         services.AddEagerService<OnlineGhostsService>();
         services.AddEagerService<RecordingService>();
         services.AddEagerService<PlayerLoopService>();
+        services.AddSingleton<BulkGhostModeState>();
         services.AddEagerService<BulkGhostRenderService>();
         services.AddEagerService<GhostPlayer>();
         services.AddEagerService<GhostMaterialService>();

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -96,6 +96,7 @@ public class Plugin : BaseUnityPlugin
         services.AddEagerService<OnlineGhostsService>();
         services.AddEagerService<RecordingService>();
         services.AddEagerService<PlayerLoopService>();
+        services.AddEagerService<BulkGhostRenderService>();
         services.AddEagerService<GhostPlayer>();
         services.AddEagerService<GhostMaterialService>();
         services.AddEagerService<GhostNamePositioniongService>();

--- a/Zeepkist.GTR.Mod.Tests/BulkGhostBatchingTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/BulkGhostBatchingTests.cs
@@ -1,0 +1,20 @@
+using TNRD.Zeepkist.GTR.Ghosting.Playback;
+using Xunit;
+
+namespace Zeepkist.GTR.Mod.Tests;
+
+public class BulkGhostBatchingTests
+{
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(0, 0)]
+    [InlineData(1, 1)]
+    [InlineData(1023, 1)]
+    [InlineData(1024, 2)]
+    [InlineData(2046, 2)]
+    [InlineData(2047, 3)]
+    public void CalculatesRequiredDrawCalls(int instanceCount, int expected)
+    {
+        Assert.Equal(expected, BulkGhostBatching.GetBatchCount(instanceCount));
+    }
+}

--- a/Zeepkist.GTR.Mod.Tests/BulkGhostBatchingTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/BulkGhostBatchingTests.cs
@@ -17,4 +17,17 @@ public class BulkGhostBatchingTests
     {
         Assert.Equal(expected, BulkGhostBatching.GetBatchCount(instanceCount));
     }
+
+    [Theory]
+    [InlineData(0, 4, 0)]
+    [InlineData(1000, 4, 4)]
+    [InlineData(1024, 4, 8)]
+    [InlineData(2000, 0, 0)]
+    public void CalculatesDrawCallsAcrossMaterialGroups(
+        int instanceCount,
+        int materialCount,
+        int expected)
+    {
+        Assert.Equal(expected, BulkGhostBatching.GetDrawCallCount(instanceCount, materialCount));
+    }
 }

--- a/Zeepkist.GTR.Mod.Tests/BulkGhostMeshScaleTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/BulkGhostMeshScaleTests.cs
@@ -1,0 +1,17 @@
+using TNRD.Zeepkist.GTR.Ghosting.Playback;
+using Xunit;
+
+namespace Zeepkist.GTR.Mod.Tests;
+
+public class BulkGhostMeshScaleTests
+{
+    [Theory]
+    [InlineData(4, 1, 4)]
+    [InlineData(2, 1, 2)]
+    [InlineData(1, 0, 1)]
+    [InlineData(1, 0.97, 1)]
+    public void CalculatesBoundsCorrection(float sourceSize, float bakedSize, float expected)
+    {
+        Assert.Equal(expected, BulkGhostMeshScale.CalculateUniformScale(sourceSize, bakedSize), 3);
+    }
+}

--- a/Zeepkist.GTR.Mod.Tests/BulkGhostModeStateTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/BulkGhostModeStateTests.cs
@@ -1,0 +1,22 @@
+using TNRD.Zeepkist.GTR.Ghosting.Playback;
+using Xunit;
+
+namespace Zeepkist.GTR.Mod.Tests;
+
+public class BulkGhostModeStateTests
+{
+    [Fact]
+    public void RaisesChangeOnlyWhenStateChanges()
+    {
+        var state = new BulkGhostModeState();
+        int changes = 0;
+        state.Changed += () => changes++;
+
+        state.SetActive(true);
+        state.SetActive(true);
+        state.SetActive(false);
+
+        Assert.False(state.IsActive);
+        Assert.Equal(2, changes);
+    }
+}

--- a/Zeepkist.GTR.Mod.Tests/GhostLoadBudgetTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/GhostLoadBudgetTests.cs
@@ -1,0 +1,24 @@
+using TNRD.Zeepkist.GTR.Ghosting.Playback;
+using Xunit;
+
+namespace Zeepkist.GTR.Mod.Tests;
+
+public class GhostLoadBudgetTests
+{
+    [Theory]
+    [InlineData(0, 0, true)]
+    [InlineData(15, 1.99, true)]
+    [InlineData(16, 0, false)]
+    [InlineData(0, 2, false)]
+    public void EnforcesCountAndTimeLimits(int processed, double elapsedMilliseconds, bool expected)
+    {
+        Assert.Equal(expected, GhostLoadBudget.CanProcessNext(processed, elapsedMilliseconds));
+    }
+
+    [Fact]
+    public void RejectsStaleGeneration()
+    {
+        Assert.True(GhostLoadBudget.IsCurrentGeneration(4, 4));
+        Assert.False(GhostLoadBudget.IsCurrentGeneration(3, 4));
+    }
+}

--- a/Zeepkist.GTR.Mod.Tests/GhostLoadProgressTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/GhostLoadProgressTests.cs
@@ -14,4 +14,19 @@ public class GhostLoadProgressTests
     {
         Assert.Equal(expected, GhostLoadProgress.CalculatePercent(completed, total));
     }
+
+    [Theory]
+    [InlineData(0, 0, false)]
+    [InlineData(1, 0, true)]
+    [InlineData(5, 5, false)]
+    [InlineData(6, 5, true)]
+    public void ReportsOnlyAfterCompletionAdvances(
+        int completed,
+        int lastReportedCompleted,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            GhostLoadProgress.HasAdvanced(completed, lastReportedCompleted));
+    }
 }

--- a/Zeepkist.GTR.Mod.Tests/GhostLoadProgressTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/GhostLoadProgressTests.cs
@@ -1,0 +1,28 @@
+using TNRD.Zeepkist.GTR.Ghosting.Playback;
+using Xunit;
+
+namespace Zeepkist.GTR.Mod.Tests;
+
+public class GhostLoadProgressTests
+{
+    [Theory]
+    [InlineData(0, 0, 100)]
+    [InlineData(0, 100, 0)]
+    [InlineData(25, 100, 25)]
+    [InlineData(150, 100, 100)]
+    public void CalculatesBoundedPercentage(int completed, int total, int expected)
+    {
+        Assert.Equal(expected, GhostLoadProgress.CalculatePercent(completed, total));
+    }
+
+    [Theory]
+    [InlineData(4, 0, false)]
+    [InlineData(5, 0, true)]
+    [InlineData(19, 15, false)]
+    [InlineData(20, 15, true)]
+    [InlineData(100, 100, true)]
+    public void ThrottlesProgressReports(int percent, int previous, bool expected)
+    {
+        Assert.Equal(expected, GhostLoadProgress.ShouldReport(percent, previous));
+    }
+}

--- a/Zeepkist.GTR.Mod.Tests/GhostLoadProgressTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/GhostLoadProgressTests.cs
@@ -14,15 +14,4 @@ public class GhostLoadProgressTests
     {
         Assert.Equal(expected, GhostLoadProgress.CalculatePercent(completed, total));
     }
-
-    [Theory]
-    [InlineData(4, 0, false)]
-    [InlineData(5, 0, true)]
-    [InlineData(19, 15, false)]
-    [InlineData(20, 15, true)]
-    [InlineData(100, 100, true)]
-    public void ThrottlesProgressReports(int percent, int previous, bool expected)
-    {
-        Assert.Equal(expected, GhostLoadProgress.ShouldReport(percent, previous));
-    }
 }

--- a/Zeepkist.GTR.Mod.Tests/GhostReconciliationTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/GhostReconciliationTests.cs
@@ -1,0 +1,27 @@
+using TNRD.Zeepkist.GTR.Ghosting.Playback;
+using Xunit;
+
+namespace Zeepkist.GTR.Mod.Tests;
+
+public class GhostReconciliationTests
+{
+    [Fact]
+    public void RetainsUnchangedSameLevelGhosts()
+    {
+        IReadOnlyList<int> obsolete = GhostReconciliation.GetObsoleteIds(
+            [1, 2, 3],
+            new HashSet<int> { 1, 2, 3 });
+
+        Assert.Empty(obsolete);
+    }
+
+    [Fact]
+    public void RemovesOnlyRecordsNoLongerDesired()
+    {
+        IReadOnlyList<int> obsolete = GhostReconciliation.GetObsoleteIds(
+            [1, 2, 3],
+            new HashSet<int> { 1, 3, 4 });
+
+        Assert.Equal([2], obsolete);
+    }
+}

--- a/Zeepkist.GTR.Mod.Tests/Zeepkist.GTR.Mod.Tests.csproj
+++ b/Zeepkist.GTR.Mod.Tests/Zeepkist.GTR.Mod.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="..\Ghosting\Playback\OfflineGhostLimit.cs" Link="Source\OfflineGhostLimit.cs" />
     <Compile Include="..\Ghosting\Playback\GhostVisualProfile.cs" Link="Source\GhostVisualProfile.cs" />
     <Compile Include="..\Ghosting\Playback\GhostVisualProfileResolver.cs" Link="Source\GhostVisualProfileResolver.cs" />
+    <Compile Include="..\Ghosting\Playback\BulkGhostBatching.cs" Link="Source\BulkGhostBatching.cs" />
     <Compile Include="..\Ghosting\Readers\GhostReaderValidation.cs" Link="Source\GhostReaderValidation.cs" />
     <Compile Include="..\Ghosting\Readers\GhostVersionReader.cs" Link="Source\GhostVersionReader.cs" />
     <Compile Include="..\Ghosting\Readers\LimitedMemoryStream.cs" Link="Source\LimitedMemoryStream.cs" />

--- a/Zeepkist.GTR.Mod.Tests/Zeepkist.GTR.Mod.Tests.csproj
+++ b/Zeepkist.GTR.Mod.Tests/Zeepkist.GTR.Mod.Tests.csproj
@@ -23,6 +23,10 @@
     <Compile Include="..\Ghosting\Playback\GhostVisualProfile.cs" Link="Source\GhostVisualProfile.cs" />
     <Compile Include="..\Ghosting\Playback\GhostVisualProfileResolver.cs" Link="Source\GhostVisualProfileResolver.cs" />
     <Compile Include="..\Ghosting\Playback\BulkGhostBatching.cs" Link="Source\BulkGhostBatching.cs" />
+    <Compile Include="..\Ghosting\Playback\BulkGhostModeState.cs" Link="Source\BulkGhostModeState.cs" />
+    <Compile Include="..\Ghosting\Playback\BulkGhostMeshScale.cs" Link="Source\BulkGhostMeshScale.cs" />
+    <Compile Include="..\Ghosting\Playback\GhostLoadBudget.cs" Link="Source\GhostLoadBudget.cs" />
+    <Compile Include="..\Ghosting\Playback\GhostReconciliation.cs" Link="Source\GhostReconciliation.cs" />
     <Compile Include="..\Ghosting\Readers\GhostReaderValidation.cs" Link="Source\GhostReaderValidation.cs" />
     <Compile Include="..\Ghosting\Readers\GhostVersionReader.cs" Link="Source\GhostVersionReader.cs" />
     <Compile Include="..\Ghosting\Readers\LimitedMemoryStream.cs" Link="Source\LimitedMemoryStream.cs" />

--- a/Zeepkist.GTR.Mod.Tests/Zeepkist.GTR.Mod.Tests.csproj
+++ b/Zeepkist.GTR.Mod.Tests/Zeepkist.GTR.Mod.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="..\Ghosting\Playback\BulkGhostModeState.cs" Link="Source\BulkGhostModeState.cs" />
     <Compile Include="..\Ghosting\Playback\BulkGhostMeshScale.cs" Link="Source\BulkGhostMeshScale.cs" />
     <Compile Include="..\Ghosting\Playback\GhostLoadBudget.cs" Link="Source\GhostLoadBudget.cs" />
+    <Compile Include="..\Ghosting\Playback\GhostLoadProgress.cs" Link="Source\GhostLoadProgress.cs" />
     <Compile Include="..\Ghosting\Playback\GhostReconciliation.cs" Link="Source\GhostReconciliation.cs" />
     <Compile Include="..\Ghosting\Readers\GhostReaderValidation.cs" Link="Source\GhostReaderValidation.cs" />
     <Compile Include="..\Ghosting\Readers\GhostVersionReader.cs" Link="Source\GhostVersionReader.cs" />

--- a/Zeepkist.GTR.Mod.csproj
+++ b/Zeepkist.GTR.Mod.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <AssemblyName>net.tnrd.zeepkist.gtr</AssemblyName>
-        <Version>0.41.1</Version>
+        <Version>0.41.2</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
         <RunPostBuildEvent>Always</RunPostBuildEvent>


### PR DESCRIPTION
- Instances bulk ghosts.
- Deferred loading of ghosts when enabling "Show All Ghosts" is clicked, or player resets to start of level to avoid frame hitching / game freezing for levels with large numbers of ghosts.
- Adds download progress notification for bulk ghosts.
- Bulk ghosts are now rendered using the default zeepkist/body textures.
- Bulk ghosts are rendered without transparency.