### PR TITLE
feat: add zeepcentraal workshop support

### DIFF
--- a/Api/RecordPostResource.cs
+++ b/Api/RecordPostResource.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace TNRD.Zeepkist.GTR.Api;
 
@@ -11,4 +12,7 @@ public class RecordPostResource
     public string GhostData { get; set; } = null!;
     public string GameVersion { get; set; } = null!;
     public string ModVersion { get; set; } = null!;
+
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public string WorkshopId { get; set; }
 }

--- a/Api/RecordWorkshopId.cs
+++ b/Api/RecordWorkshopId.cs
@@ -4,9 +4,17 @@ namespace TNRD.Zeepkist.GTR.Api;
 
 public static class RecordWorkshopId
 {
-    public static string ToWireValue(ulong workshopId, bool isAdventureLevel, bool useAvonturenLevel)
+    public static string ToWireValue(
+        ulong lobbyWorkshopId,
+        ulong levelWorkshopId,
+        bool isAdventureLevel,
+        bool useAvonturenLevel)
     {
-        if (workshopId == 0 || isAdventureLevel || useAvonturenLevel)
+        if (isAdventureLevel || useAvonturenLevel)
+            return null;
+
+        ulong workshopId = lobbyWorkshopId != 0 ? lobbyWorkshopId : levelWorkshopId;
+        if (workshopId == 0)
             return null;
 
         return workshopId.ToString(CultureInfo.InvariantCulture);

--- a/Api/RecordWorkshopId.cs
+++ b/Api/RecordWorkshopId.cs
@@ -1,0 +1,14 @@
+using System.Globalization;
+
+namespace TNRD.Zeepkist.GTR.Api;
+
+public static class RecordWorkshopId
+{
+    public static string ToWireValue(ulong workshopId, bool isAdventureLevel, bool useAvonturenLevel)
+    {
+        if (workshopId == 0 || isAdventureLevel || useAvonturenLevel)
+            return null;
+
+        return workshopId.ToString(CultureInfo.InvariantCulture);
+    }
+}

--- a/Ghosting/Recording/RecordingService.cs
+++ b/Ghosting/Recording/RecordingService.cs
@@ -100,12 +100,17 @@ public class RecordingService : IEagerService, IDisposable
         _logger.LogInformation("Collecting extra information");
         string hash = LevelApi.CurrentHash;
         LevelScriptableObject currentLevel = LevelApi.CurrentLevel;
-        string workshopId = currentLevel == null
-            ? null
-            : RecordWorkshopId.ToWireValue(
-                currentLevel.WorkshopID,
-                currentLevel.IsAdventureLevel,
-                currentLevel.UseAvonturenLevel);
+        string workshopId = RecordWorkshopId.ToWireValue(
+            ZeepkistNetwork.CurrentLobby?.WorkshopID ?? 0,
+            currentLevel?.WorkshopID ?? 0,
+            currentLevel?.IsAdventureLevel ?? false,
+            currentLevel?.UseAvonturenLevel ?? false);
+
+        _logger.LogInformation(
+            "Resolved workshop ID {WorkshopId} from lobby {LobbyWorkshopId} and level {LevelWorkshopId}",
+            workshopId ?? "<none>",
+            ZeepkistNetwork.CurrentLobby?.WorkshopID ?? 0,
+            currentLevel?.WorkshopID ?? 0);
 
         if (string.IsNullOrEmpty(hash))
         {

--- a/Ghosting/Recording/RecordingService.cs
+++ b/Ghosting/Recording/RecordingService.cs
@@ -99,6 +99,13 @@ public class RecordingService : IEagerService, IDisposable
 
         _logger.LogInformation("Collecting extra information");
         string hash = LevelApi.CurrentHash;
+        LevelScriptableObject currentLevel = LevelApi.CurrentLevel;
+        string workshopId = currentLevel == null
+            ? null
+            : RecordWorkshopId.ToWireValue(
+                currentLevel.WorkshopID,
+                currentLevel.IsAdventureLevel,
+                currentLevel.UseAvonturenLevel);
 
         if (string.IsNullOrEmpty(hash))
         {
@@ -126,7 +133,7 @@ public class RecordingService : IEagerService, IDisposable
             return;
         }
 
-        await Submit(hash, time, splits, speeds, ghostData);
+        await Submit(hash, workshopId, time, splits, speeds, ghostData);
     }
 
     private async UniTask<string> ProcessGhostRecorder(GhostRecorder ghostRecorder)
@@ -164,6 +171,7 @@ public class RecordingService : IEagerService, IDisposable
 
     private async UniTask Submit(
         string hash,
+        string workshopId,
         float time,
         List<float> splits,
         List<float> speeds,
@@ -173,6 +181,7 @@ public class RecordingService : IEagerService, IDisposable
         RecordPostResource resource = new()
         {
             Level = hash,
+            WorkshopId = workshopId,
             Time = time,
             Splits = splits,
             Speeds = speeds,

--- a/Zeepkist.GTR.Mod.Tests/RecordWorkshopIdTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/RecordWorkshopIdTests.cs
@@ -9,16 +9,39 @@ public class RecordWorkshopIdTests
     [Fact]
     public void UsesDecimalStringForWorkshopLevel()
     {
-        Assert.Equal("18446744073709551615", RecordWorkshopId.ToWireValue(ulong.MaxValue, false, false));
+        Assert.Equal(
+            "18446744073709551615",
+            RecordWorkshopId.ToWireValue(ulong.MaxValue, 0, false, false));
+    }
+
+    [Fact]
+    public void UsesLobbyWorkshopIdBeforeClonedLevelValue()
+    {
+        Assert.Equal("3749321871", RecordWorkshopId.ToWireValue(3749321871, 0, false, false));
+    }
+
+    [Fact]
+    public void FallsBackToLevelWorkshopId()
+    {
+        Assert.Equal("3749321871", RecordWorkshopId.ToWireValue(0, 3749321871, false, false));
     }
 
     [Theory]
-    [InlineData(0, false, false)]
-    [InlineData(1, true, false)]
-    [InlineData(1, false, true)]
-    public void OmitsAdventureAndZeroWorkshopIds(ulong workshopId, bool adventure, bool avonturen)
+    [InlineData(0, 0, false, false)]
+    [InlineData(1, 1, true, false)]
+    [InlineData(1, 1, false, true)]
+    public void OmitsAdventureAndZeroWorkshopIds(
+        ulong lobbyWorkshopId,
+        ulong levelWorkshopId,
+        bool adventure,
+        bool avonturen)
     {
-        Assert.Null(RecordWorkshopId.ToWireValue(workshopId, adventure, avonturen));
+        Assert.Null(
+            RecordWorkshopId.ToWireValue(
+                lobbyWorkshopId,
+                levelWorkshopId,
+                adventure,
+                avonturen));
     }
 
     [Fact]

--- a/Zeepkist.GTR.Mod.Tests/RecordWorkshopIdTests.cs
+++ b/Zeepkist.GTR.Mod.Tests/RecordWorkshopIdTests.cs
@@ -1,0 +1,37 @@
+using Newtonsoft.Json;
+using TNRD.Zeepkist.GTR.Api;
+using Xunit;
+
+namespace Zeepkist.GTR.Mod.Tests;
+
+public class RecordWorkshopIdTests
+{
+    [Fact]
+    public void UsesDecimalStringForWorkshopLevel()
+    {
+        Assert.Equal("18446744073709551615", RecordWorkshopId.ToWireValue(ulong.MaxValue, false, false));
+    }
+
+    [Theory]
+    [InlineData(0, false, false)]
+    [InlineData(1, true, false)]
+    [InlineData(1, false, true)]
+    public void OmitsAdventureAndZeroWorkshopIds(ulong workshopId, bool adventure, bool avonturen)
+    {
+        Assert.Null(RecordWorkshopId.ToWireValue(workshopId, adventure, avonturen));
+    }
+
+    [Fact]
+    public void NullWorkshopIdIsOmittedFromJson()
+    {
+        RecordPostResource resource = new()
+        {
+            Level = "hash",
+            WorkshopId = null
+        };
+
+        string json = JsonConvert.SerializeObject(resource);
+
+        Assert.DoesNotContain("\"WorkshopId\"", json);
+    }
+}

--- a/Zeepkist.GTR.Mod.Tests/Zeepkist.GTR.Mod.Tests.csproj
+++ b/Zeepkist.GTR.Mod.Tests/Zeepkist.GTR.Mod.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
@@ -17,6 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Api\RecordPostResource.cs" Link="Source\RecordPostResource.cs" />
+    <Compile Include="..\Api\RecordWorkshopId.cs" Link="Source\RecordWorkshopId.cs" />
     <Compile Include="..\Configuration\ServiceUriValidator.cs" Link="Source\ServiceUriValidator.cs" />
     <Compile Include="..\Ghosting\GhostLimits.cs" Link="Source\GhostLimits.cs" />
     <Compile Include="..\Ghosting\Playback\OfflineGhostLimit.cs" Link="Source\OfflineGhostLimit.cs" />

--- a/Zeepkist.GTR.Mod.csproj
+++ b/Zeepkist.GTR.Mod.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <AssemblyName>net.tnrd.zeepkist.gtr</AssemblyName>
-        <Version>0.41.2</Version>
+        <Version>1.0.0</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
         <RunPostBuildEvent>Always</RunPostBuildEvent>


### PR DESCRIPTION
Adds support for ZeepCentraal's initial workshop support.

The latest version of ZeepCentraal will restrict record submissions to GTR 1.0.0 clients only.

Please do not release this version until ZeepCentraal is live.