### PR TITLE
fix: update minimum ZeepSDK version to 2.3.1 to avoid adventure level hash conflict

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -31,7 +31,7 @@ using ZeepSDK.Storage;
 namespace TNRD.Zeepkist.GTR;
 
 [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
-[BepInDependency("ZeepSDK", "1.44.3")]
+[BepInDependency("ZeepSDK", "2.3.1")]
 public class Plugin : BaseUnityPlugin
 {
     private IHost _host;

--- a/Zeepkist.GTR.Mod.csproj
+++ b/Zeepkist.GTR.Mod.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net472</TargetFramework>
         <AssemblyName>net.tnrd.zeepkist.gtr</AssemblyName>
-        <Version>1.1.0</Version>
+        <Version>1.1.1</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
         <RunPostBuildEvent>Always</RunPostBuildEvent>
@@ -46,7 +46,7 @@
         <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
         <PackageReference Include="StrawberryShake.Transport.Http" Version="14.3.0" />
         <PackageReference Include="Zeepkist.GameLibs" Version="17.15.1867" PrivateAssets="all" />
-        <PackageReference Include="ZeepSDK" Version="2.3.0" PrivateAssets="all" />
+        <PackageReference Include="ZeepSDK" Version="2.3.1" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Updates minimum ZeepSDK version to 2.3.1
- GTR 1.1.1 is the minimum supported version to continue submitting records